### PR TITLE
Linkify overexuberance

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -48,7 +48,9 @@ TLDS.reverse()
 
 url_re = re.compile(r"""\b(?:[\w-]+:/{0,3})?  # http://
                     (?<!@)([\w-]+\.)+(?:%s)     # xx.yy.tld
-                    (?:[/?]\S*)?              # /path/zz
+                    (?:[/?][^\s\{\}\|\\\^\[\]`<>"\x80-\xFF\x00-\x1F\x7F]*)?
+                        # /path/zz (excluding "unsafe" chars from RFC 1738,
+                        # except for # and ~, which happen in practice)
                     \b                        # Break at a word boundary.
                     """ % u'|'.join(TLDS),
                     re.VERBOSE)

--- a/bleach/tests/test_links.py
+++ b/bleach/tests/test_links.py
@@ -134,3 +134,10 @@ def test_javascript_url():
     """javascript: urls should never be linkified."""
     s = 'javascript:document.vulnerable'
     eq_(s, b.linkify(s))
+
+
+def test_unsafe_url():
+    """Any unsafe char ({}[]<>, etc.) in the path should end URL scanning."""
+    eq_('All your{"<a href="http://xx.yy.com/grover.png" '
+                     'rel="nofollow">xx.yy.com/grover.png</a>"}base are',
+        b.linkify('All your{"xx.yy.com/grover.png"}base are'))


### PR DESCRIPTION
This keeps linkify() from pulling neighboring impossible-to-be-in-a-URL stuff into a URL stuff into a URL. E.g., {hi there}http://things.com/stuff/to/do{go away} no longer makes {go away} part of the URL.
