### PR TITLE
linkifying emails

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -94,7 +94,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
 
 def linkify(text, nofollow=True, filter_url=identity,
-            filter_text=identity, skip_pre=False):
+            filter_text=identity, skip_pre=False, parse_email=False):
     """Convert URL-like strings in an HTML fragment to links.
 
     linkify() converts strings that look like URLs or domain names in a
@@ -134,12 +134,13 @@ def linkify(text, nofollow=True, filter_url=identity,
     def linkify_nodes(tree, parse_text=True):
         for node in tree.childNodes:
             if node.type == NODE_TEXT and parse_text:
-                new_frag = re.sub(email_re, email_repl, node.toxml())
-                if new_frag != node.toxml():
-                    replace_nodes(tree, new_frag, node)
-                    linkify_nodes(tree, False)
-                    continue
-
+                new_frag = node.toxml()
+                if parse_email:
+                    new_frag = re.sub(email_re, email_repl, new_frag)
+                    if new_frag != node.toxml():
+                        replace_nodes(tree, new_frag, node)
+                        linkify_nodes(tree, False)
+                        continue
                 new_frag = re.sub(url_re, link_repl, new_frag)
                 replace_nodes(tree, new_frag, node)
             elif node.name == 'a':

--- a/bleach/tests/test_links.py
+++ b/bleach/tests/test_links.py
@@ -48,11 +48,13 @@ def test_mangle_link():
 
 
 def test_email_link():
-    eq_('a <a href="mailto:james@example.com" rel="nofollow">james@example.com</a> mailto',
+    eq_('a james@example.com mailto',
         linkify('a james@example.com mailto'))
-
+    eq_('a <a href="mailto:james@example.com" rel="nofollow">james@example.com</a> mailto',
+        linkify('a james@example.com mailto', parse_email=True))
     eq_('email to <a href="james@example.com" rel="nofollow">james@example.com</a>',
-        linkify('email to <a href="james@example.com">james@example.com</a>'))
+        linkify('email to <a href="james@example.com">james@example.com</a>', parse_email=True))
+
 
 
 def test_tlds():


### PR DESCRIPTION
I have added support for bleach to linkify email addresses into &lt;a href="mailto:"&gt; tag. I hope that it is really useful commit.

I also changed test_email_link() to check that it works right.

``` bash
~/projects/bleach $ nosetests
.................................................................
----------------------------------------------------------------------
Ran 65 tests in 0.374s

OK
```

Thanks.
