### PR TITLE
Now it is possible to filter attribute values by passing callable in BLEACH_ATTRIBUTES

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,9 @@ to customize their behavior.
 | ``attributes``     | A whitelist of HTML attributes. Either a list, in     |
 |                    | which case all attributes are allowed on all elements,|
 |                    | or a dict, with tag names as keys and lists of allowed|
-|                    | attributes as values. Defaults to                     |
+|                    | attributes as values. Or it is possible to pass a     |
+|                    | callable instead of a list that accepts name and value|
+|                    | of attribute and returns True of False. Defaults to   |
 |                    | ``bleach.ALLOWED_ATTRIBUTES``.                        |
 +--------------------+-------------------------------------------------------+
 | ``styles``         | A whitelist of allowed CSS properties within a        |

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -15,7 +15,10 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
         """Sanitize a token either by HTML-encoding or dropping.
 
         Unlike HTMLSanitizerMixin.sanitize_token, allowed_attributes can be
-        a dict of 'tag' => ['attribute', 'pairs'].
+        a dict of {'tag': ['attribute', 'pairs'], 'tag': callable}.
+
+        Here callable is a function with two arguments of attribute name
+        and value. It should return true of false.
 
         Also gives the option to strip tags instead of encoding.
 
@@ -32,7 +35,9 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
                         allowed_attributes = self.allowed_attributes
                     attrs = dict([(name, val) for name, val in
                                   token['data'][::-1]
-                                  if name in allowed_attributes])
+                                  if (allowed_attributes(name, val) 
+                                      if callable(allowed_attributes)
+                                      else name in allowed_attributes)])
                     for attr in self.attr_val_is_uri:
                         if not attr in attrs:
                             continue

--- a/bleach/tests/test_security.py
+++ b/bleach/tests/test_security.py
@@ -51,6 +51,18 @@ def test_invalid_href_attr():
         clean('<a href="javascript:alert(\'XSS\')">xss</a>'))
 
 
+def test_invalid_filter_attr():
+    IMG = ['img', ]
+    IMG_ATTR = {'img': lambda name, val: name == 'src' and val == "http://example.com/"}
+
+    eq_('<img src="http://example.com/">',
+        clean('<img onclick="evil" src="http://example.com/" />',
+                tags=IMG, attributes=IMG_ATTR))
+
+    eq_('<img>', clean('<img onclick="evil" src="http://badhost.com/" />',
+                       tags=IMG, attributes=IMG_ATTR))
+
+
 def test_invalid_tag_char():
     eq_('&lt;script xss="" src="http://xx.com/xss.js"&gt;&lt;/script&gt;',
         clean('<script/xss src="http://xx.com/xss.js"></script>'))


### PR DESCRIPTION
Example: 

BLEACH_ATTRIBUTES = {
    'a': ['href', 'title', 'name', 'target'],
    'abbr': ['title'],
    'acronym': ['title'],
    'img': ['src', 'alt'],
    'iframe': lambda name, val: name=='src' and re.match(r'http://www.youtube.com/', val),
    }
