### PR TITLE
Unicode Safe URL Regex

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging
 import re
 import sys
@@ -60,10 +61,10 @@ url_re = re.compile(
     r"""\(*  # Match any opening parentheses.
     \b(?<![@.])(?:\w[\w-]*:/{0,3}(?:(?:\w+:)?\w+@)?)?  # http://
     ([\w-]+\.)+(?:%s)(?!\.\w)\b   # xx.yy.tld
-    (?:[/?][^\s\{\}\|\\\^\[\]`<>"\x80-\xFF\x00-\x1F\x7F]*)?
+    (?:[/?][^\s\{\}\|\\\^\[\]`<>"\s]*)?
         # /path/zz (excluding "unsafe" chars from RFC 1738,
         # except for # and ~, which happen in practice)
-    """ % u'|'.join(TLDS), re.VERBOSE)
+    """ % u'|'.join(TLDS), re.VERBOSE | re.UNICODE)
 
 proto_re = re.compile(r'^[\w-]+:/{0,3}')
 
@@ -123,6 +124,11 @@ def linkify(text, nofollow=True, filter_url=identity,
     already found in the document, the href attribute is passed through
     filter_url(), but the text is untouched.
     """
+    # If you want to match modern unicode URLs
+    # you need to make the string UTF8.
+    # This will become obsolete with py3.
+    if not isinstance(text, unicode):
+        text = text.decode('utf8')
 
     if not text:
         return u''

--- a/bleach/tests/test_links.py
+++ b/bleach/tests/test_links.py
@@ -240,6 +240,7 @@ def test_sarcasm():
     clean = u'Yeah right &lt;sarcasm/&gt;'
     eq_(clean, linkify(dirty))
 
+
 def test_wrapping_parentheses():
     """urls wrapped in balanced paranthesis shall not include them in the href
     """

--- a/bleach/tests/test_unicode.py
+++ b/bleach/tests/test_unicode.py
@@ -31,3 +31,24 @@ def test_mixed_linkify():
     eq_(u'Домашняя <a href="http://example.com" rel="nofollow">'
         u'http://example.com</a> ヘルプとチュートリアル',
         linkify(u'Домашняя http://example.com ヘルプとチュートリアル'))
+
+
+def test_url_utf8():
+    """Allow UTF8 characters in URLs themselves."""
+    out = u'<a href="%(url)s" rel="nofollow">%(url)s</a>'
+
+    tests = (
+        ('http://éxámplé.com/', out % {'url': u'http://éxámplé.com/'}),
+        ('http://éxámplé.com/íàñá/',
+                out % {'url': u'http://éxámplé.com/íàñá/'}),
+        ('http://éxámplé.com/íàñá/?foo=bar',
+            out % {'url': u'http://éxámplé.com/íàñá/?foo=bar'}),
+        ('http://éxámplé.com/íàñá/?fóo=bár',
+            out % {'url': u'http://éxámplé.com/íàñá/?fóo=bár'}),
+    )
+
+    def check(test, expected_output):
+        eq_(expected_output, linkify(test))
+
+    for test, expected_output in tests:
+        yield check, test, expected_output


### PR DESCRIPTION
Hello again :)
I've tried to fix the url regex so it also works with utf8 characters. It works, however I'm not quite sure how secure my change the regex is.

The tests pass, so it can't be that bad (I hope). Did test it with some [ASCII control characters](http://en.wikipedia.org/wiki/ASCII#ASCII_control_characters) and they don't match. So I guess it should be quite secure?

I would really appreciate your feedback :-)
