### PR TITLE
make stripping comments False by default [bug 664533]

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -85,7 +85,7 @@ identity = lambda x: x  # The identity function.
 
 
 def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-          styles=ALLOWED_STYLES, strip=False, strip_comments=True):
+          styles=ALLOWED_STYLES, strip=False, strip_comments=False):
     """Clean an HTML fragment and return it"""
     if not text:
         return u''


### PR DESCRIPTION
comments are used to prevent links in the wiki [bug 664533]
