### PR TITLE
Fix mailto: URLs breaking in delinkify()

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -313,7 +313,7 @@ def delinkify(text, allow_domains=None, allow_mailto=None,
                     host = parts.hostname
                     if host is None and allow_relative:
                         continue
-                    if any(_domain_match(host, d) for d in allow_domains):
+                    if host is not None and any(_domain_match(host, d) for d in allow_domains):
                         continue
                 # Replace the node with its children.
                 # You can't nest <a> tags, and html5lib takes care of that

--- a/bleach/tests/test_delinkify.py
+++ b/bleach/tests/test_delinkify.py
@@ -48,6 +48,8 @@ def test_relative_allow_domains():
     eq_('some link', bleach.delinkify(html))
     eq_(html, bleach.delinkify(html, allow_relative=True,
                                allow_domains=['ex.mp']))
+    eq_('some link', bleach.delinkify(html, allow_relative=False,
+                               allow_domains=['ex.mp']))
 
 
 def test_protocol_relative():


### PR DESCRIPTION
Found a bug while running our test suite.
