### PR TITLE
TypeError: __init__() got an unexpected keyword argument 'parser'

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -124,9 +124,9 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
 
 class BleachSanitizer(HTMLTokenizer, BleachSanitizerMixin):
     def __init__(self, stream, encoding=None, parseMeta=True, useChardet=True,
-                 lowercaseElementName=True, lowercaseAttrName=True):
+                 lowercaseElementName=True, lowercaseAttrName=True, **kwargs):
         HTMLTokenizer.__init__(self, stream, encoding, parseMeta, useChardet,
-                               lowercaseElementName, lowercaseAttrName)
+                               lowercaseElementName, lowercaseAttrName, **kwargs)
 
     def __iter__(self):
         for token in HTMLTokenizer.__iter__(self):


### PR DESCRIPTION
Hi,
I've stumbled upon an issue today when installing html5lib. Since version 0.95 the init signature adds a parser argument that's missing from the BleachSanitizer. So, i just extended it to accept keyword values arguments, this way any further changes in html5lib will be compatible with Bleach.
Regards,
