### PR TITLE
Test to reproduce hang in sanitize_styles

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -106,7 +106,7 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
         # TODO: Make sure this does what it's meant to - I *think* it wants to
         # validate style attribute contents.
         parts = style.split(';')
-        gauntlet = re.compile("""^([-:,;#%.\sa-zA-Z0-9!]|\w-\w|'[\s\w]+"""
+        gauntlet = re.compile("""^([-/:,#%.\sa-zA-Z0-9!]|\w-\w|'[\s\w]+"""
                               """'|"[\s\w]+"|\([\d,\s]+\))*$""")
         for part in parts:
             if not gauntlet.match(part):

--- a/bleach/tests/test_css.py
+++ b/bleach/tests/test_css.py
@@ -54,8 +54,8 @@ def test_style_hang():
         'background-color',
         'font', 'font-size', 'font-weight', 'text-align', 'text-transform',
     ]
-    expected_style = """margin-top: 0px; margin-right: 0px; margin-bottom: 1.286em; margin-left: 0px; padding-top: 15px; padding-right: 15px; padding-bottom: 15px; padding-left: 15px; background-color: rgb(246, 246, 242); font: normal normal normal 100%/normal 'Courier New', 'Andale Mono', monospace;"""
+
+    expected = """<p style="margin-top: 0px; margin-right: 0px; margin-bottom: 1.286em; margin-left: 0px; padding-top: 15px; padding-right: 15px; padding-bottom: 15px; padding-left: 15px; background-color: rgb(246, 246, 242); font: normal normal normal 100%/normal 'Courier New', 'Andale Mono', monospace;">Hello world</p>"""
 
     result = clean(html, styles=styles)
-
-    ok_(True)
+    eq_(expected, result)


### PR DESCRIPTION
This is not intended as a complete PR, so much as an illustration of the problem and a call for help.

The regex check I commented out in `sanitizer.py` appears to suffer from a hang, when fed the inline styles that appear in the new test. 

Of course, the funny thing is that all tests pass with this regex check commented out, so it might not be that important after all? :)

FWIW, as crazy as it looks, this is data "in the wild" from [a page on the MDN wiki](https://developer.mozilla.org/en/SpiderMonkey/Build_Documentation), and it causes the migration process to come to a halt.

I haven't spent too much time dissecting the regex itself, yet. But, I have found that the length of the hang can be reduced by removing some of the styles. I haven't been able to narrow it down to just one style, though. So, that makes me think that it's not an infinite loop per se, but just a very very long process for this given set of inline styles. 

However, the hang is so long on my laptop that it never finished for me after letting it go while I wandered off for an hour for lunch. That seems troublesome.
