### PR TITLE
Add sanitize option to linkify()

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -6,6 +6,7 @@ import urlparse
 
 import html5lib
 from html5lib.sanitizer import HTMLSanitizer
+from html5lib.tokenizer import HTMLTokenizer
 from html5lib.serializer.htmlserializer import HTMLSerializer
 
 from encoding import force_unicode
@@ -109,7 +110,8 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
 
 def linkify(text, nofollow=True, target=None, filter_url=identity,
-            filter_text=identity, skip_pre=False, parse_email=False):
+            filter_text=identity, skip_pre=False, parse_email=False,
+            tokenizer=HTMLSanitizer):
     """Convert URL-like strings in an HTML fragment to links.
 
     linkify() converts strings that look like URLs or domain names in a
@@ -136,7 +138,7 @@ def linkify(text, nofollow=True, target=None, filter_url=identity,
     if not text:
         return u''
 
-    parser = html5lib.HTMLParser(tokenizer=HTMLSanitizer)
+    parser = html5lib.HTMLParser(tokenizer=tokenizer)
 
     forest = parser.parseFragment(text)
 


### PR DESCRIPTION
Sometimes sanitization is not wanted when linkifying. Add an option to enable it only if necessary.
It defaults to off since that makes more sense in my optinion (you do not expect a method `linkify` to escape some tags!)
