### PR TITLE
Switch to skip CSS gauntlet; allow rect(40px, 200px, 150px, 30px)

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -91,7 +91,8 @@ RECURSION_EXCEPTION = RuntimeError if not PY_26 else AttributeError
 
 
 def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-          styles=ALLOWED_STYLES, strip=False, strip_comments=True):
+          styles=ALLOWED_STYLES, strip=False, strip_comments=True,
+          skip_gauntlet=False):
     """Clean an HTML fragment and return it"""
     if not text:
         return u''
@@ -106,6 +107,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
         allowed_css_properties = styles
         strip_disallowed_elements = strip
         strip_html_comments = strip_comments
+        skip_css_gauntlet = skip_gauntlet
 
     parser = html5lib.HTMLParser(tokenizer=s)
 

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -102,15 +102,24 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
         # disallow urls
         style = re.compile('url\s*\(\s*[^\s)]+?\s*\)\s*').sub(' ', style)
 
-        # gauntlet
-        # TODO: Make sure this does what it's meant to - I *think* it wants to
-        # validate style attribute contents.
-        parts = style.split(';')
-        gauntlet = re.compile("""^([-/:,#%.'\sa-zA-Z0-9!]|\w-\w|'[\s\w]+'\s*"""
-                              """|"[\s\w]+"|\([\d,%\.\s]+\))*$""")
-        for part in parts:
-            if not gauntlet.match(part):
-                return ''
+        if not self.skip_css_gauntlet:
+            # gauntlet
+            # TODO: Make sure this does what it's meant to - I *think* it wants
+            # to validate style attribute contents.
+            parts = style.split(';')
+            gauntlet = re.compile("""
+            ^(
+                # TODO: Is there anything that the following does *not* allow?
+                [-/:,#%.'\sa-zA-Z0-9!\(\)] |
+                \w-\w |          # eg. a-a, 0-0, a-0 (TODO: what's it for?)
+                '[\s\w]+'\s* |   # eg. 'foo' 'bar' 'baz' 
+                "[\s\w]+"\s* |   # eg. "foo" "bar" "baz"
+                \([\d,%\.\s]+\)  # eg. (100% 50% 10%); (1.0 0.5 0.1)
+            )*$
+            """, re.VERBOSE)
+            for part in parts:
+                if not gauntlet.match(part):
+                    return ''
 
         if not re.match("^\s*([-\w]+\s*:[^:;]*(;\s*|$))*$", style):
             return ''


### PR DESCRIPTION
More annoying quirks with that gauntlet regex, this time blocking rect().

[@teoli2003 suggested removing the test on styles altogether](https://bugzilla.mozilla.org/show_bug.cgi?id=776603#c23). I'm not sure that's easily done, but I've also added a `skip_css_gauntlet` flag that could let us get around what look like repeat issues in MDN. It defaults to `False`, so should be backwards compatible if other users rely on it.
