### PR TITLE
Allow double-quotes in styles

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -108,7 +108,7 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
         # TODO: Make sure this does what it's meant to - I *think* it wants to
         # validate style attribute contents.
         parts = style.split(';')
-        gauntlet = re.compile("""^([-/:,#%.'\sa-zA-Z0-9!]|\w-\w|'[\s\w]+'\s*"""
+        gauntlet = re.compile("""^([-/:,#%.'"\sa-zA-Z0-9!]|\w-\w|'[\s\w]+'\s*"""
                               """|"[\s\w]+"|\([\d,%\.\s]+\))*$""")
         for part in parts:
             if not gauntlet.match(part):

--- a/bleach/tests/test_css.py
+++ b/bleach/tests/test_css.py
@@ -23,6 +23,8 @@ def test_allowed_css():
         ('color: hsl(30,100%,50%);', 'color: hsl(30,100%,50%);', ['color']),
         ('color: rgba(255,0,0,0.4);', 'color: rgba(255,0,0,0.4);', ['color']),
         ("text-overflow: ',' ellipsis;", "text-overflow: ',' ellipsis;", ['text-overflow']),
+        ("font-family:'Arial','sans-serif'", "font-family: 'Arial','sans-serif';",
+            ['font-family'])
     )
 
     p = '<p style="%s">bar</p>'
@@ -33,6 +35,36 @@ def test_allowed_css():
     for i, o, s in tests:
         yield check, i, o, s
 
+def test_allowed_css_single_quote():
+    tests = (
+        ("font-family: Arial; color: red; float: left; "
+         'background-color: red;', 'color: red;', ['color']),
+        ("border: 1px solid blue; color: red; float: left;", 'color: red;',
+         ['color']),
+        ("border: 1px solid blue; color: red; float: left;",
+         'color: red; float: left;', ['color', 'float']),
+        ("color: red; float: left; padding: 1em;", 'color: red; float: left;',
+         ['color', 'float']),
+        ("color: red; float: left; padding: 1em;", 'color: red;', ['color']),
+        ("cursor: -moz-grab;", 'cursor: -moz-grab;', ['cursor']),
+        ("color: hsl(30,100%,50%);", 'color: hsl(30,100%,50%);', ['color']),
+        ("color: rgba(255,0,0,0.4);", 'color: rgba(255,0,0,0.4);', ['color']),
+        ('text-overflow: "," ellipsis;', 'text-overflow: "," ellipsis;', ['text-overflow']),
+        ('font-family:"Arial","sans-serif"', 'font-family: "Arial","sans-serif";',
+            ['font-family'])
+    )
+
+    p =  "<p style='%s'>bar</p>"
+    p2 = '<p style="%s">bar</p>'
+
+    def check(input, output, styles):
+        if '"' in output:
+            eq_(p % output, clean(p % input, styles=styles))
+        else: 
+            eq_(p2 % output, clean(p % input, styles=styles))
+
+    for i, o, s in tests:
+        yield check, i, o, s
 
 def test_valid_css():
     """The sanitizer should fix missing CSS values."""


### PR DESCRIPTION
CSS and HTML allow either single or double-quotes for its attributes.
Unfortunately, the css guantlet in the sanitizer rejects CSS containing
double-quotes.

The changes here add double-quotes to the set of allowed characters. A
new test ensures that clean works on single-quoted style attributes
containing double-quotes
