### PR TITLE
bleach.clean doesn't strip whitespace anymore.

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -99,7 +99,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
     text = force_unicode(text)
     if text.startswith(u'<!--'):
-        text = u' ' + text
+        text = u'' + text
 
     class s(BleachSanitizer):
         allowed_elements = tags
@@ -110,7 +110,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
     parser = html5lib.HTMLParser(tokenizer=s)
 
-    return _render(parser.parseFragment(text)).strip()
+    return _render(parser.parseFragment(text))
 
 
 def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False,

--- a/bleach/tests/test_basics.py
+++ b/bleach/tests/test_basics.py
@@ -8,6 +8,11 @@ def test_empty():
     eq_('', bleach.clean(''))
 
 
+def test_nbsp():
+    eq_(u'\xa0test string\xa0', bleach.clean('&nbsp;test string&nbsp;'))
+
+
+ 
 def test_comments_only():
     comment = '<!-- this is a comment -->'
     open_comment = '<!-- this is an open comment'


### PR DESCRIPTION
Several WYSIWYG editor can start a document with `&nbsp;` or some other whitespace characters. 
If those characters are stripped, the document itself will be changed.
This request fixes this problem.
