### PR TITLE
Removed "...::Web Environment::Mozilla" classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
-        'Environment :: Web Environment :: Mozilla',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Removed the `'Environment :: Web Environment :: Mozilla',` from `classifiers` in `setup.py` as I see no particular reason to signal/limit use of Bleach to a 'Mozilla' web environment only.

Perhaps it is my limited understanding of the Trove classifiers... in which case you can simply close this PR as uneducated, no worries :-)
