### PR TITLE
Need to pin html5lib in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,6 @@ envlist = py26, py27, py32, py33, pypy
 [testenv]
 commands = nosetests {posargs:-v}
 deps =
+    six
+    html5lib==0.999
     nose


### PR DESCRIPTION
Using `tox` locally for testing and checking the `.tox/py27/lib/python2.7/site-packages/` folder for the actual versions being used, found that `html5lib` was _not_ 0.999 as expected... specifying just "html5lib" in `tox.ini` didn't fix this (it kept on getting 1.0b3, which is probably due to the backtracking of html5lib versions...)

Therefore, this PR proposes to pin the `html5lib` in `tox.ini` to allow `tox` for local testing to use the most recent version. That is: v0.999 at this moment, subject to change by future `html5lib` releases; which unfortunately will require rebasing the version.
