### PR TITLE
Allow protocols and svg properties to be configurable.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,3 +26,4 @@ Patches:
 - Marc DM
 - mdxs
 - Marc Abramowitz
+- Dave St.Germain

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -95,7 +95,8 @@ DEFAULT_CALLBACKS = [linkify_callbacks.nofollow]
 
 
 def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-          styles=ALLOWED_STYLES, strip=False, strip_comments=True):
+          styles=ALLOWED_STYLES, strip=False, strip_comments=True, protocols=HTMLSanitizer.acceptable_protocols,
+          svg_properties=None):
     """Clean an HTML fragment and return it"""
     if not text:
         return ''
@@ -108,6 +109,8 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
         allowed_css_properties = styles
         strip_disallowed_elements = strip
         strip_html_comments = strip_comments
+        allowed_protocols = protocols
+        allowed_svg_properties = svg_properties or []
 
     parser = html5lib.HTMLParser(tokenizer=s)
 

--- a/bleach/tests/test_basics.py
+++ b/bleach/tests/test_basics.py
@@ -194,3 +194,18 @@ def test_sarcasm():
     dirty = 'Yeah right <sarcasm/>'
     clean = 'Yeah right &lt;sarcasm/&gt;'
     eq_(clean, bleach.clean(dirty))
+
+def test_img_data():
+    dirty = '<img src="data:image/png;ABCDEF==" class="data" />'
+    clean = '<img src="data:image/png;ABCDEF==">'
+    eq_(clean, bleach.clean(dirty, tags=['img'], attributes=['src'], protocols=['data']))
+
+def test_svg():
+    dirty = '''
+    <svg width="100" height="100"><circle cx="50" cy="50" r="40" style="stroke:green;stroke-width:4;fill:yellow" /></svg>
+    '''.strip()
+    clean = '''<svg><circle style="stroke: green; fill: yellow;"></circle></svg>'''
+    tags = ['svg', 'circle']
+    attributes = ['style']
+    svg_properties = ['stroke', 'fill']
+    eq_(clean, bleach.clean(dirty, tags=tags, attributes=attributes, svg_properties=svg_properties))


### PR DESCRIPTION
I wanted to allow `data` URIs in images, and in order to do that I had to be able to set `allowed_protocols` and plumb it through to the sanitizer. While I was in there, I made the `allowed_svg_properties` attribute configurable, too.