### PR TITLE
Allow Data URI Schemes

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -57,8 +57,9 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
                         # characters.
                         val_unescaped = val_unescaped.replace("\ufffd", "")
                         if (re.match(r'^[a-z0-9][-+.a-z0-9]*:', val_unescaped)
-                            and (val_unescaped.split(':')[0] not in
-                                 self.allowed_protocols)):
+                                and (val_unescaped.split(':')[0] not in
+                                     self.allowed_protocols)
+                                and val_unescaped.split(':')[0] != 'data'):
                             del attrs[attr]
                     for attr in self.svg_attr_val_allows_ref:
                         if attr in attrs:


### PR DESCRIPTION
Allow the 'data' pseudo-protocol as established with https://en.wikipedia.org/wiki/Data_URI_scheme#Format. There is a current PR for html5lib to add 'data' to acceptable_protocols ([PR #148](https://github.com/html5lib/html5lib-python/pull/148)), but this prevents Bleach from incorrectly deleting URI attributes with the 'data' protocol until html5lib is fixed.