### PR TITLE
Whitelist allowed tags by callable

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -34,7 +34,8 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
 
         if token['type'] in (tokenTypes['StartTag'], tokenTypes['EndTag'],
                              tokenTypes['EmptyTag']):
-            if (self.allowed_elements(token['name'])
+            if (
+                self.allowed_elements(token['name'])
                 if callable(self.allowed_elements)
                 else token['name'] in self.allowed_elements
             ):
@@ -52,7 +53,7 @@ class BleachSanitizerMixin(HTMLSanitizerMixin):
                                       if callable(allowed_attributes)
                                       else name in allowed_attributes)])
                     for attr in self.attr_val_is_uri:
-                        if not attr in attrs:
+                        if attr not in attrs:
                             continue
                         val_unescaped = re.sub("[`\000-\040\177-\240\s]+", '',
                                                unescape(attrs[attr])).lower()

--- a/bleach/tests/test_basics.py
+++ b/bleach/tests/test_basics.py
@@ -71,8 +71,10 @@ def test_function_arguments_attributes():
     }
 
     eq_('<img alt="Bla"><img href="bla.jpg">',
-        bleach.clean('<img alt="Bla"><img href="bla.jpg" style="display: none;">',
-                     tags=['img'], attributes=ATTRS))
+        bleach.clean(
+            '<img alt="Bla"><img href="bla.jpg" style="display: none;">',
+            tags=['img'], attributes=ATTRS
+        ))
 
 
 def test_function_arguments_tags():


### PR DESCRIPTION
This adds the possibility to filter the tags by function, similar to the way its done for attributes.

Our use-case here is that we want to dis-allow `script` and other evil tags but don't want to allow an ever-growing whitelist. And our users often add things like `<username here>` in their texts...

I don't know if there is a better way to tell python that the allowed_tags-function is a static function.

Oh, I also renamed the tests for attributes to `bleach.clean` and added a test for the attribute-filter function.
