### PR TITLE
tox.ini: Use pytest and pytest-sugar

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,10 @@
 envlist = py26, py27, py32, py33, py34, pypy
 
 [testenv]
-commands = nosetests {posargs:-v}
+commands = py.test {posargs}
 deps =
     six
     html5lib==0.999
     nose
+    pytest
+    pytest-sugar


### PR DESCRIPTION
@jsocol: You don't have to merge this. Choice of test runner is a very personal decision. But I used to be a nose person and I've come to love pytest and pytest-sugar and I did it locally for my own hacking and thought I'd share it, just in case, you also find it useful. I won't be offended if you don't merge though.

##### Screenshot

![screen shot 2014-12-13 at 4 53 15 pm](https://cloud.githubusercontent.com/assets/305268/5426001/9589c6c2-82e9-11e4-840f-23c56d960097.png)
