### PR TITLE
Made protocols configurable.

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import copy
 import logging
 import re
 
@@ -44,7 +43,7 @@ ALLOWED_ATTRIBUTES = {
 
 ALLOWED_STYLES = []
 
-ALLOWED_PROTOCOLS = copy.copy(HTMLSanitizer.acceptable_protocols)
+ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']
 
 TLDS = """ac ad ae aero af ag ai al am an ao aq ar arpa as asia at au aw ax az
        ba bb bd be bf bg bh bi biz bj bm bn bo br bs bt bv bw by bz ca cat

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+import copy
 import logging
 import re
 
@@ -43,7 +44,7 @@ ALLOWED_ATTRIBUTES = {
 
 ALLOWED_STYLES = []
 
-ALLOWED_PROTOCOLS = HTMLSanitizer.acceptable_protocols.copy()
+ALLOWED_PROTOCOLS = copy.copy(HTMLSanitizer.acceptable_protocols)
 
 TLDS = """ac ad ae aero af ag ai al am an ao aq ar arpa as asia at au aw ax az
        ba bb bd be bf bg bh bi biz bj bm bn bo br bs bt bv bw by bz ca cat

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -43,6 +43,8 @@ ALLOWED_ATTRIBUTES = {
 
 ALLOWED_STYLES = []
 
+ALLOWED_PROTOCOLS = HTMLSanitizer.acceptable_protocols.copy()
+
 TLDS = """ac ad ae aero af ag ai al am an ao aq ar arpa as asia at au aw ax az
        ba bb bd be bf bg bh bi biz bj bm bn bo br bs bt bv bw by bz ca cat
        cc cd cf cg ch ci ck cl cm cn co com coop cr cu cv cx cy cz de dj dk
@@ -96,7 +98,8 @@ DEFAULT_CALLBACKS = [linkify_callbacks.nofollow]
 
 
 def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-          styles=ALLOWED_STYLES, strip=False, strip_comments=True):
+          styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
+          strip_comments=True):
     """Clean an HTML fragment and return it"""
     if not text:
         return ''
@@ -107,6 +110,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
         allowed_elements = tags
         allowed_attributes = attributes
         allowed_css_properties = styles
+        allowed_protocols = protocols
         strip_disallowed_elements = strip
         strip_html_comments = strip_comments
 

--- a/bleach/tests/test_basics.py
+++ b/bleach/tests/test_basics.py
@@ -194,3 +194,14 @@ def test_sarcasm():
     dirty = 'Yeah right <sarcasm/>'
     clean = 'Yeah right &lt;sarcasm/&gt;'
     eq_(clean, bleach.clean(dirty))
+
+
+def test_user_defined_protocols_valid():
+    valid_href = '<a href="my_protocol://more_text">allowed href</a>'
+    eq_(valid_href, bleach.clean(valid_href, protocols=['my_protocol']))
+
+
+def test_user_defined_protocols_invalid():
+    invalid_href = '<a href="http://xx.com">invalid href</a>'
+    cleaned_href = '<a>invalid href</a>'
+    eq_(cleaned_href, bleach.clean(invalid_href, protocols=['my_protocol']))

--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -92,6 +92,21 @@ For example, to allow users to set the color and font-weight of text::
     cleaned_text = bleach.clean(text, tags, attrs, styles)
 
 
+Protocol Whitelist
+==================
+
+If you allow tags that have attributes containing a URI value (like the ``href``
+attribute of an anchor tag, you may want to adapt the accepted protocols. The
+default list only allows ``http``, ``https`` and ``mailto``.
+
+For example, to allow the smb protocol as well::
+
+    >>> html = '<a href="smb://more_text">allowed protocol</a>'
+
+    >>> bleach.clean(html, protocols=['http', 'https', 'mailto', 'smb'])
+    u'<a href="smb://more_text">allowed protocol</a>'
+
+
 Stripping Markup
 ================
 


### PR DESCRIPTION
For one of my projects, I required configurable protocols for the href attribute of anchor tags when using bleach.clean. This pull request exposes the allowed protocols in bleach.clean.