### PR TITLE
Add skip_code option to linkify()

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -116,7 +116,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
 
 def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False,
-            parse_email=False, tokenizer=HTMLSanitizer):
+            skip_code=False, parse_email=False, tokenizer=HTMLSanitizer):
     """Convert URL-like strings in an HTML fragment to links.
 
     linkify() converts strings that look like URLs or domain names in a
@@ -297,7 +297,8 @@ def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False,
                         _seen.add(node)
 
             elif current_child >= 0:
-                if node.tag == ETREE_TAG('pre') and skip_pre:
+                if (node.tag == ETREE_TAG('pre') and skip_pre) or \
+                   (node.tag == ETREE_TAG('code') and skip_code):
                     linkify_nodes(node, False)
                 elif not (node in _seen):
                     linkify_nodes(node, True)

--- a/bleach/tests/test_links.py
+++ b/bleach/tests/test_links.py
@@ -315,6 +315,23 @@ def test_skip_pre():
     eq_(nofollowed, linkify(already_linked, skip_pre=True))
 
 
+def test_skip_code():
+    """Skip linkification in <code> tags."""
+    simple = 'http://xx.com <code>http://xx.com</code>'
+    linked = ('<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
+              '<code>http://xx.com</code>')
+    all_linked = ('<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
+                  '<code><a href="http://xx.com" rel="nofollow">http://xx.com'
+                  '</a></code>')
+    eq_(linked, linkify(simple, skip_code=True))
+    eq_(all_linked, linkify(simple))
+
+    already_linked = '<code><a href="http://xx.com">xx</a></code>'
+    nofollowed = '<code><a href="http://xx.com" rel="nofollow">xx</a></code>'
+    eq_(nofollowed, linkify(already_linked))
+    eq_(nofollowed, linkify(already_linked, skip_code=True))
+
+
 def test_libgl():
     """libgl.so.1 should not be linkified."""
     eq_('libgl.so.1', linkify('libgl.so.1'))

--- a/docs/linkify.rst
+++ b/docs/linkify.rst
@@ -184,6 +184,13 @@ any new links within a ``<pre>`` section, pass ``skip_pre=True``.
    tags will still be passed through all the callbacks.
 
 
+``skip_code``
+============
+
+This option acts just like the ``skip_pre`` option, except it operates
+on ``<code>`` tags instead of ``<pre>`` tags.
+
+
 ``parse_email``
 ===============
 


### PR DESCRIPTION
The markdown parser I'm using is rendering code blocks like
`<pre><code> ... </code></pre>` instead of `<pre> ... </pre>`.
This is breaking the `skip_pre` behavior, and attempting to linkify
URLs within my code blocks. Adding a skip_code option to linkify
and enabling it fixes my problem.

Let me know if you have any suggestions here.