### PR TITLE
Limit html5lib version before sanitizer API changes get released

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ordereddict
 six
-html5lib>=0.999
+html5lib>=0.999,<0.99999999
 
 # Requirements to run the test suite:
 nose


### PR DESCRIPTION
Now https://github.com/html5lib/html5lib-python/pull/110 has landed, Bleach needs to limit its version of html5lib until it's changed to follow the new API. (This is likely going to be the last breaking API change that will affect Bleach until 2.0.)
