### PR TITLE
changed max prereq to 0.9999999 as 0.99999999 was created a couple of…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ordereddict
 six
-html5lib>=0.999,<0.99999999
+html5lib>=0.999,<0.9999999
 
 # Requirements to run the test suite:
 nose


### PR DESCRIPTION
… days ago and was even not backward compatible so that bleach breaks. See https://github.com/mozilla/bleach/issues/212