### PR TITLE
html5lib moved location of sanitizer for ver 0.99999999 and up

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -11,7 +11,10 @@ except ImportError:
 import re
 
 import html5lib
-from html5lib.sanitizer import HTMLSanitizer
+try:
+    from html5lib.filters.sanitizer import HTMLSanitizer
+except ImportError:
+    from html5lib.sanitizer import HTMLSanitizer
 from html5lib.serializer.htmlserializer import HTMLSerializer
 
 from . import callbacks as linkify_callbacks


### PR DESCRIPTION
I was getting an error with bleach with the latest version of html5lib, version 0.99999999. Appears the import for HTMLSanitizer has moved locations. Not sure if this is the best way to fix this but worked with 0.9999 and 0.999999999.