### PR TITLE
ref #204 - Move test_suite to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
 install:
 - pip install -r requirements.txt
 script:
-- nosetests
+- py.test
 - flake8 bleach/
 deploy:
   provider: pypi

--- a/bleach/tests/test_basics.py
+++ b/bleach/tests/test_basics.py
@@ -1,13 +1,12 @@
 import six
 import html5lib
-from nose.tools import eq_
 
 import bleach
 from bleach.tests.tools import in_
 
 
 def test_empty():
-    eq_('', bleach.clean(''))
+    assert '' == bleach.clean('')
 
 
 def test_nbsp():
@@ -16,48 +15,49 @@ def test_nbsp():
     else:
         expected = six.u('\\xa0test string\\xa0')
 
-    eq_(expected, bleach.clean('&nbsp;test string&nbsp;'))
+    assert expected == bleach.clean('&nbsp;test string&nbsp;')
 
 
 def test_comments_only():
     comment = '<!-- this is a comment -->'
     open_comment = '<!-- this is an open comment'
-    eq_('', bleach.clean(comment))
-    eq_('', bleach.clean(open_comment))
-    eq_(comment, bleach.clean(comment, strip_comments=False))
-    eq_('{0!s}-->'.format(open_comment), bleach.clean(open_comment,
-                                                      strip_comments=False))
+    assert '' == bleach.clean(comment)
+    assert '' == bleach.clean(open_comment)
+    assert comment == bleach.clean(comment, strip_comments=False)
+    assert '{0!s}-->'.format(open_comment) == \
+        bleach.clean(open_comment,
+                     strip_comments=False)
 
 
 def test_with_comments():
     html = '<!-- comment -->Just text'
-    eq_('Just text', bleach.clean(html))
-    eq_(html, bleach.clean(html, strip_comments=False))
+    assert 'Just text' == bleach.clean(html)
+    assert html == bleach.clean(html, strip_comments=False)
 
 
 def test_no_html():
-    eq_('no html string', bleach.clean('no html string'))
+    assert 'no html string' == bleach.clean('no html string')
 
 
 def test_allowed_html():
-    eq_('an <strong>allowed</strong> tag',
-        bleach.clean('an <strong>allowed</strong> tag'))
-    eq_('another <em>good</em> tag',
-        bleach.clean('another <em>good</em> tag'))
+    assert 'an <strong>allowed</strong> tag' == \
+        bleach.clean('an <strong>allowed</strong> tag')
+    assert 'another <em>good</em> tag' == \
+        bleach.clean('another <em>good</em> tag')
 
 
 def test_bad_html():
-    eq_('a <em>fixed tag</em>',
-        bleach.clean('a <em>fixed tag'))
+    assert 'a <em>fixed tag</em>' == \
+        bleach.clean('a <em>fixed tag')
 
 
 def test_function_arguments():
     TAGS = ['span', 'br']
     ATTRS = {'span': ['style']}
 
-    eq_('a <br><span style="">test</span>',
+    assert 'a <br><span style="">test</span>' == \
         bleach.clean('a <br/><span style="color:red">test</span>',
-                     tags=TAGS, attributes=ATTRS))
+                     tags=TAGS, attributes=ATTRS)
 
 
 def test_named_arguments():
@@ -65,73 +65,74 @@ def test_named_arguments():
     s = ('<a href="http://xx.com" rel="alternate">xx.com</a>',
          '<a rel="alternate" href="http://xx.com">xx.com</a>')
 
-    eq_('<a href="http://xx.com">xx.com</a>', bleach.clean(s[0]))
+    assert '<a href="http://xx.com">xx.com</a>' == bleach.clean(s[0])
     in_(s, bleach.clean(s[0], attributes=ATTRS))
 
 
 def test_disallowed_html():
-    eq_('a &lt;script&gt;safe()&lt;/script&gt; test',
-        bleach.clean('a <script>safe()</script> test'))
-    eq_('a &lt;style&gt;body{}&lt;/style&gt; test',
-        bleach.clean('a <style>body{}</style> test'))
+    assert 'a &lt;script&gt;safe()&lt;/script&gt; test' == \
+        bleach.clean('a <script>safe()</script> test')
+    assert 'a &lt;style&gt;body{}&lt;/style&gt; test' == \
+        bleach.clean('a <style>body{}</style> test')
 
 
 def test_bad_href():
-    eq_('<em>no link</em>',
-        bleach.clean('<em href="fail">no link</em>'))
+    assert '<em>no link</em>' == \
+        bleach.clean('<em href="fail">no link</em>')
 
 
 def test_bare_entities():
-    eq_('an &amp; entity', bleach.clean('an & entity'))
-    eq_('an &lt; entity', bleach.clean('an < entity'))
-    eq_('tag &lt; <em>and</em> entity',
-        bleach.clean('tag < <em>and</em> entity'))
-    eq_('&amp;', bleach.clean('&amp;'))
+    assert 'an &amp; entity' == bleach.clean('an & entity')
+    assert 'an &lt; entity' == bleach.clean('an < entity')
+    assert 'tag &lt; <em>and</em> entity' == \
+        bleach.clean('tag < <em>and</em> entity')
+    assert '&amp;' == bleach.clean('&amp;')
 
 
 def test_escaped_entities():
     s = '&lt;em&gt;strong&lt;/em&gt;'
-    eq_(s, bleach.clean(s))
+    assert s == bleach.clean(s)
 
 
 def test_serializer():
     s = '<table></table>'
-    eq_(s, bleach.clean(s, tags=['table']))
-    eq_('test<table></table>', bleach.linkify('<table>test</table>'))
-    eq_('<p>test</p>', bleach.clean('<p>test</p>', tags=['p']))
+    assert s == bleach.clean(s, tags=['table'])
+    assert 'test<table></table>' == bleach.linkify('<table>test</table>')
+    assert '<p>test</p>' == bleach.clean('<p>test</p>', tags=['p'])
 
 
 def test_no_href_links():
     s = '<a name="anchor">x</a>'
-    eq_(s, bleach.linkify(s))
+    assert s == bleach.linkify(s)
 
 
 def test_weird_strings():
     s = '</3'
-    eq_(bleach.clean(s), '')
+    assert bleach.clean(s) == ''
 
 
 def test_xml_render():
     parser = html5lib.HTMLParser()
-    eq_(bleach._render(parser.parseFragment('')), '')
+    assert bleach._render(parser.parseFragment('')) == ''
 
 
 def test_stripping():
-    eq_('a test <em>with</em> <b>html</b> tags',
-        bleach.clean('a test <em>with</em> <b>html</b> tags', strip=True))
-    eq_('a test <em>with</em>  <b>html</b> tags',
+    assert 'a test <em>with</em> <b>html</b> tags' == \
+        bleach.clean('a test <em>with</em> <b>html</b> tags', strip=True)
+    assert 'a test <em>with</em>  <b>html</b> tags' == \
         bleach.clean('a test <em>with</em> <img src="http://example.com/"> '
-                     '<b>html</b> tags', strip=True))
+                     '<b>html</b> tags', strip=True)
 
     s = '<p><a href="http://example.com/">link text</a></p>'
-    eq_('<p>link text</p>', bleach.clean(s, tags=['p'], strip=True))
+    assert '<p>link text</p>' == bleach.clean(s, tags=['p'], strip=True)
     s = '<p><span>multiply <span>nested <span>text</span></span></span></p>'
-    eq_('<p>multiply nested text</p>', bleach.clean(s, tags=['p'], strip=True))
+    assert '<p>multiply nested text</p>' == \
+        bleach.clean(s, tags=['p'], strip=True)
 
     s = ('<p><a href="http://example.com/"><img src="http://example.com/">'
          '</a></p>')
-    eq_('<p><a href="http://example.com/"></a></p>',
-        bleach.clean(s, tags=['p', 'a'], strip=True))
+    assert '<p><a href="http://example.com/"></a></p>' == \
+        bleach.clean(s, tags=['p', 'a'], strip=True)
 
 
 def test_allowed_styles():
@@ -139,10 +140,10 @@ def test_allowed_styles():
     STYLE = ['color']
     blank = '<b style=""></b>'
     s = '<b style="color: blue;"></b>'
-    eq_(blank, bleach.clean('<b style="top:0"></b>', attributes=ATTR))
-    eq_(s, bleach.clean(s, attributes=ATTR, styles=STYLE))
-    eq_(s, bleach.clean('<b style="top: 0; color: blue;"></b>',
-                        attributes=ATTR, styles=STYLE))
+    assert blank == bleach.clean('<b style="top:0"></b>', attributes=ATTR)
+    assert s == bleach.clean(s, attributes=ATTR, styles=STYLE)
+    assert s == bleach.clean('<b style="top: 0; color: blue;"></b>',
+                             attributes=ATTR, styles=STYLE)
 
 
 def test_idempotent():
@@ -150,10 +151,10 @@ def test_idempotent():
     dirty = '<span>invalid & </span> < extra http://link.com<em>'
 
     clean = bleach.clean(dirty)
-    eq_(clean, bleach.clean(clean))
+    assert clean == bleach.clean(clean)
 
     linked = bleach.linkify(dirty)
-    eq_(linked, bleach.linkify(linked))
+    assert linked == bleach.linkify(linked)
 
 
 def test_rel_already_there():
@@ -173,7 +174,7 @@ def test_lowercase_html():
     """We should output lowercase HTML."""
     dirty = '<EM CLASS="FOO">BAR</EM>'
     clean = '<em class="FOO">BAR</em>'
-    eq_(clean, bleach.clean(dirty, attributes=['class']))
+    assert clean == bleach.clean(dirty, attributes=['class'])
 
 
 def test_wildcard_attributes():
@@ -193,15 +194,16 @@ def test_sarcasm():
     """Jokes should crash.<sarcasm/>"""
     dirty = 'Yeah right <sarcasm/>'
     clean = 'Yeah right &lt;sarcasm/&gt;'
-    eq_(clean, bleach.clean(dirty))
+    assert clean == bleach.clean(dirty)
 
 
 def test_user_defined_protocols_valid():
     valid_href = '<a href="my_protocol://more_text">allowed href</a>'
-    eq_(valid_href, bleach.clean(valid_href, protocols=['my_protocol']))
+    assert valid_href == bleach.clean(valid_href, protocols=['my_protocol'])
 
 
 def test_user_defined_protocols_invalid():
     invalid_href = '<a href="http://xx.com">invalid href</a>'
     cleaned_href = '<a>invalid href</a>'
-    eq_(cleaned_href, bleach.clean(invalid_href, protocols=['my_protocol']))
+    assert cleaned_href == \
+        bleach.clean(invalid_href, protocols=['my_protocol'])

--- a/bleach/tests/test_css.py
+++ b/bleach/tests/test_css.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-from nose.tools import eq_
-
 from bleach import clean
 
 
@@ -34,9 +32,9 @@ def test_allowed_css():
 
     def check(i, o, s):
         if '"' in i:
-            eq_(p_double.format(o), clean(p_double.format(i), styles=s))
+            assert p_double.format(o) == clean(p_double.format(i), styles=s)
         else:
-            eq_(p_single.format(o), clean(p_single.format(i), styles=s))
+            assert p_single.format(o) == clean(p_single.format(i), styles=s)
 
     for i, o, s in tests:
         yield check, i, o, s
@@ -45,10 +43,10 @@ def test_allowed_css():
 def test_valid_css():
     """The sanitizer should fix missing CSS values."""
     styles = ['color', 'float']
-    eq_('<p style="float: left;">foo</p>',
-        clean('<p style="float: left; color: ">foo</p>', styles=styles))
-    eq_('<p style="">foo</p>',
-        clean('<p style="color: float: left;">foo</p>', styles=styles))
+    assert '<p style="float: left;">foo</p>' == \
+        clean('<p style="float: left; color: ">foo</p>', styles=styles)
+    assert '<p style="">foo</p>' == \
+        clean('<p style="color: float: left;">foo</p>', styles=styles)
 
 
 def test_style_hang():
@@ -91,4 +89,4 @@ def test_style_hang():
                 """Hello world</p>""")
 
     result = clean(html, styles=styles)
-    eq_(expected, result)
+    assert expected == result

--- a/bleach/tests/test_links.py
+++ b/bleach/tests/test_links.py
@@ -4,7 +4,6 @@ except ImportError:
     from urllib import quote_plus
 
 from html5lib.tokenizer import HTMLTokenizer
-from nose.tools import eq_
 
 from bleach import linkify, url_re, DEFAULT_CALLBACKS as DC
 
@@ -18,29 +17,31 @@ def test_url_re():
 
 
 def test_empty():
-    eq_('', linkify(''))
+    assert '' == linkify('')
 
 
 def test_simple_link():
-    eq_('a <a href="http://example.com" rel="nofollow">http://example.com'
-        '</a> link',
-        linkify('a http://example.com link'))
-    eq_('a <a href="https://example.com" rel="nofollow">https://example.com'
-        '</a> link',
-        linkify('a https://example.com link'))
-    eq_('a <a href="http://example.com" rel="nofollow">example.com</a> link',
-        linkify('a example.com link'))
+    assert 'a <a href="http://example.com" rel="nofollow">http://example.com'
+    '</a> link' == \
+        linkify('a http://example.com link')
+    assert 'a <a href="https://example.com" rel="nofollow">https://example.com'
+    '</a> link' == \
+        linkify('a https://example.com link')
+    assert 'a <a href="http://example.com" rel="nofollow">example.com'
+    '</a> link' == \
+        linkify('a example.com link')
 
 
 def test_trailing_slash():
-    eq_('<a href="http://examp.com/" rel="nofollow">http://examp.com/</a>',
-        linkify('http://examp.com/'))
-    eq_('<a href="http://example.com/foo/" rel="nofollow">'
-        'http://example.com/foo/</a>',
-        linkify('http://example.com/foo/'))
-    eq_('<a href="http://example.com/foo/bar/" rel="nofollow">'
-        'http://example.com/foo/bar/</a>',
-        linkify('http://example.com/foo/bar/'))
+    assert '<a href="http://examp.com/" rel="nofollow">http://examp.com/'
+    '</a>' == \
+        linkify('http://examp.com/')
+    assert '<a href="http://example.com/foo/" rel="nofollow">'
+    'http://example.com/foo/</a>' == \
+        linkify('http://example.com/foo/')
+    assert '<a href="http://example.com/foo/bar/" rel="nofollow">'
+    'http://example.com/foo/bar/</a>' == \
+        linkify('http://example.com/foo/bar/')
 
 
 def test_mangle_link():
@@ -50,9 +51,9 @@ def test_mangle_link():
         attrs['href'] = 'http://bouncer/?u={0!s}'.format(quoted)
         return attrs
 
-    eq_('<a href="http://bouncer/?u=http%3A%2F%2Fexample.com" rel="nofollow">'
-        'http://example.com</a>',
-        linkify('http://example.com', DC + [filter_url]))
+    assert '<a href="http://bouncer/?u=http%3A%2F%2Fexample.com" '
+    'rel="nofollow">http://example.com</a>' == \
+        linkify('http://example.com', DC + [filter_url])
 
 
 def test_mangle_text():
@@ -62,8 +63,9 @@ def test_mangle_text():
         attrs['_text'] = 'bar'
         return attrs
 
-    eq_('<a href="http://ex.mp">bar</a> <a href="http://ex.mp/foo">bar</a>',
-        linkify('http://ex.mp <a href="http://ex.mp/foo">foo</a>', [ft]))
+    assert '<a href="http://ex.mp">bar</a> <a href="http://ex.mp/foo">bar'
+    '</a>' == \
+        linkify('http://ex.mp <a href="http://ex.mp/foo">foo</a>', [ft])
 
 
 def test_email_link():
@@ -88,7 +90,7 @@ def test_email_link():
     )
 
     def _check(o, p, i):
-        eq_(o, linkify(i, parse_email=p))
+        assert o == linkify(i, parse_email=p)
 
     for (o, p, i) in tests:
         yield _check, o, p, i
@@ -108,7 +110,7 @@ def test_email_link_escaping():
     )
 
     def _check(o, i):
-        eq_(o, linkify(i, parse_email=True))
+        assert o == linkify(i, parse_email=True)
 
     for (o, i) in tests:
         yield _check, o, i
@@ -144,7 +146,7 @@ def test_prevent_links():
     )
 
     def _check(cb, o, msg):
-        eq_(o, linkify(in_text, cb), msg)
+        assert o, linkify(in_text, cb) == msg
 
     for (cb, o, msg) in tests:
         yield _check, cb, o, msg
@@ -157,8 +159,8 @@ def test_set_attrs():
         attrs['rev'] = 'canonical'
         return attrs
 
-    eq_('<a href="http://ex.mp" rev="canonical">ex.mp</a>',
-        linkify('ex.mp', [set_attr]))
+    assert '<a href="http://ex.mp" rev="canonical">ex.mp</a>' == \
+        linkify('ex.mp', [set_attr])
 
 
 def test_only_proto_links():
@@ -171,7 +173,7 @@ def test_only_proto_links():
     in_text = 'a ex.mp http://ex.mp <a href="/foo">bar</a>'
     out_text = ('a ex.mp <a href="http://ex.mp">http://ex.mp</a> '
                 '<a href="/foo">bar</a>')
-    eq_(out_text, linkify(in_text, [only_proto]))
+    assert out_text, linkify(in_text == [only_proto])
 
 
 def test_stop_email():
@@ -181,121 +183,124 @@ def test_stop_email():
             return None
         return attrs
     text = 'do not link james@example.com'
-    eq_(text, linkify(text, parse_email=True, callbacks=[no_email]))
+    assert text == linkify(text, parse_email=True, callbacks=[no_email])
 
 
 def test_tlds():
-    eq_('<a href="http://example.com" rel="nofollow">example.com</a>',
-        linkify('example.com'))
-    eq_('<a href="http://example.co" rel="nofollow">example.co</a>',
-        linkify('example.co'))
-    eq_('<a href="http://example.co.uk" rel="nofollow">example.co.uk</a>',
-        linkify('example.co.uk'))
-    eq_('<a href="http://example.edu" rel="nofollow">example.edu</a>',
-        linkify('example.edu'))
-    eq_('<a href="http://example.xxx" rel="nofollow">example.xxx</a>',
-        linkify('example.xxx'))
-    eq_('example.yyy', linkify('example.yyy'))
-    eq_(' brie', linkify(' brie'))
-    eq_('<a href="http://bit.ly/fun" rel="nofollow">bit.ly/fun</a>',
-        linkify('bit.ly/fun'))
+    assert '<a href="http://example.com" rel="nofollow">example.com</a>' == \
+        linkify('example.com')
+    assert '<a href="http://example.co" rel="nofollow">example.co'
+    '</a>' == \
+        linkify('example.co')
+    assert '<a href="http://example.co.uk" rel="nofollow">'
+    'example.co.uk</a>' == \
+        linkify('example.co.uk')
+    assert '<a href="http://example.edu" rel="nofollow">example.edu</a>' == \
+        linkify('example.edu')
+    assert '<a href="http://example.xxx" rel="nofollow">example.xxx</a>' == \
+        linkify('example.xxx')
+    assert 'example.yyy' == linkify('example.yyy')
+    assert ' brie' == linkify(' brie')
+    assert '<a href="http://bit.ly/fun" rel="nofollow">bit.ly/fun</a>' == \
+        linkify('bit.ly/fun')
 
 
 def test_escaping():
-    eq_('&lt; unrelated', linkify('< unrelated'))
+    assert '&lt; unrelated' == linkify('< unrelated')
 
 
 def test_nofollow_off():
-    eq_('<a href="http://example.com">example.com</a>',
-        linkify('example.com', []))
+    assert '<a href="http://example.com">example.com</a>' == \
+        linkify('example.com', [])
 
 
 def test_link_in_html():
-    eq_('<i><a href="http://yy.com" rel="nofollow">http://yy.com</a></i>',
-        linkify('<i>http://yy.com</i>'))
+    assert '<i><a href="http://yy.com" rel="nofollow">http://yy.com'
+    '</a></i>' == \
+        linkify('<i>http://yy.com</i>')
 
-    eq_('<em><strong><a href="http://xx.com" rel="nofollow">http://xx.com'
-        '</a></strong></em>',
-        linkify('<em><strong>http://xx.com</strong></em>'))
+    assert '<em><strong><a href="http://xx.com" rel="nofollow">http://xx.com'
+    '</a></strong></em>' == \
+        linkify('<em><strong>http://xx.com</strong></em>')
 
 
 def test_links_https():
-    eq_('<a href="https://yy.com" rel="nofollow">https://yy.com</a>',
-        linkify('https://yy.com'))
+    assert '<a href="https://yy.com" rel="nofollow">https://yy.com</a>' == \
+        linkify('https://yy.com')
 
 
 def test_add_rel_nofollow():
     """Verify that rel="nofollow" is added to an existing link"""
-    eq_('<a href="http://yy.com" rel="nofollow">http://yy.com</a>',
-        linkify('<a href="http://yy.com">http://yy.com</a>'))
+    assert '<a href="http://yy.com" rel="nofollow">http://yy.com</a>' == \
+        linkify('<a href="http://yy.com">http://yy.com</a>')
 
 
 def test_url_with_path():
-    eq_('<a href="http://example.com/path/to/file" rel="nofollow">'
-        'http://example.com/path/to/file</a>',
-        linkify('http://example.com/path/to/file'))
+    assert '<a href="http://example.com/path/to/file" rel="nofollow">'
+    'http://example.com/path/to/file</a>' == \
+        linkify('http://example.com/path/to/file')
 
 
 def test_link_ftp():
-    eq_('<a href="ftp://ftp.mozilla.org/some/file" rel="nofollow">'
-        'ftp://ftp.mozilla.org/some/file</a>',
-        linkify('ftp://ftp.mozilla.org/some/file'))
+    assert '<a href="ftp://ftp.mozilla.org/some/file" rel="nofollow">'
+    'ftp://ftp.mozilla.org/some/file</a>' == \
+        linkify('ftp://ftp.mozilla.org/some/file')
 
 
 def test_link_query():
-    eq_('<a href="http://xx.com/?test=win" rel="nofollow">'
-        'http://xx.com/?test=win</a>',
-        linkify('http://xx.com/?test=win'))
-    eq_('<a href="http://xx.com/?test=win" rel="nofollow">'
-        'xx.com/?test=win</a>',
-        linkify('xx.com/?test=win'))
-    eq_('<a href="http://xx.com?test=win" rel="nofollow">'
-        'xx.com?test=win</a>',
-        linkify('xx.com?test=win'))
+    assert '<a href="http://xx.com/?test=win" rel="nofollow">'
+    'http://xx.com/?test=win</a>' == \
+        linkify('http://xx.com/?test=win')
+    assert '<a href="http://xx.com/?test=win" rel="nofollow">'
+    'xx.com/?test=win</a>' == \
+        linkify('xx.com/?test=win')
+    assert '<a href="http://xx.com?test=win" rel="nofollow">'
+    'xx.com?test=win</a>' == \
+        linkify('xx.com?test=win')
 
 
 def test_link_fragment():
-    eq_('<a href="http://xx.com/path#frag" rel="nofollow">'
-        'http://xx.com/path#frag</a>',
-        linkify('http://xx.com/path#frag'))
+    assert '<a href="http://xx.com/path#frag" rel="nofollow">'
+    'http://xx.com/path#frag</a>' == \
+        linkify('http://xx.com/path#frag')
 
 
 def test_link_entities():
-    eq_('<a href="http://xx.com/?a=1&amp;b=2" rel="nofollow">'
-        'http://xx.com/?a=1&amp;b=2</a>',
-        linkify('http://xx.com/?a=1&b=2'))
+    assert '<a href="http://xx.com/?a=1&amp;b=2" rel="nofollow">'
+    'http://xx.com/?a=1&amp;b=2</a>' == \
+        linkify('http://xx.com/?a=1&b=2')
 
 
 def test_escaped_html():
     """If I pass in escaped HTML, it should probably come out escaped."""
     s = '&lt;em&gt;strong&lt;/em&gt;'
-    eq_(s, linkify(s))
+    assert s == linkify(s)
 
 
 def test_link_http_complete():
-    eq_('<a href="https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d'
-        '&amp;e#f" rel="nofollow">'
-        'https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d&amp;e#f</a>',
-        linkify('https://user:pass@ftp.mozilla.org/x/y.exe?a=b&c=d&e#f'))
+    assert '<a href="https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d'
+    '&amp;e#f" rel="nofollow">'
+    'https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d&amp;e#f</a>' == \
+        linkify('https://user:pass@ftp.mozilla.org/x/y.exe?a=b&c=d&e#f')
 
 
 def test_non_url():
     """document.vulnerable should absolutely not be linkified."""
     s = 'document.vulnerable'
-    eq_(s, linkify(s))
+    assert s == linkify(s)
 
 
 def test_javascript_url():
     """javascript: urls should never be linkified."""
     s = 'javascript:document.vulnerable'
-    eq_(s, linkify(s))
+    assert s == linkify(s)
 
 
 def test_unsafe_url():
     """Any unsafe char ({}[]<>, etc.) in the path should end URL scanning."""
-    eq_('All your{"<a href="http://xx.yy.com/grover.png" '
-        'rel="nofollow">xx.yy.com/grover.png</a>"}base are',
-        linkify('All your{"xx.yy.com/grover.png"}base are'))
+    assert 'All your{"<a href="http://xx.yy.com/grover.png" '
+    'rel="nofollow">xx.yy.com/grover.png</a>"}base are' == \
+        linkify('All your{"xx.yy.com/grover.png"}base are')
 
 
 def test_skip_pre():
@@ -306,25 +311,24 @@ def test_skip_pre():
     all_linked = ('<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
                   '<pre><a href="http://xx.com" rel="nofollow">http://xx.com'
                   '</a></pre>')
-    eq_(linked, linkify(simple, skip_pre=True))
-    eq_(all_linked, linkify(simple))
+    assert linked == linkify(simple, skip_pre=True)
+    assert all_linked == linkify(simple)
 
     already_linked = '<pre><a href="http://xx.com">xx</a></pre>'
     nofollowed = '<pre><a href="http://xx.com" rel="nofollow">xx</a></pre>'
-    eq_(nofollowed, linkify(already_linked))
-    eq_(nofollowed, linkify(already_linked, skip_pre=True))
+    assert nofollowed == linkify(already_linked)
+    assert nofollowed == linkify(already_linked, skip_pre=True)
 
-    eq_(
+    assert \
         linkify('<pre><code>http://example.com</code></pre>http://example.com',
-                skip_pre=True),
+                skip_pre=True) == \
         ('<pre><code>http://example.com</code></pre>'
          '<a href="http://example.com" rel="nofollow">http://example.com</a>')
-    )
 
 
 def test_libgl():
     """libgl.so.1 should not be linkified."""
-    eq_('libgl.so.1', linkify('libgl.so.1'))
+    assert 'libgl.so.1' == linkify('libgl.so.1')
 
 
 def test_end_of_sentence():
@@ -333,8 +337,8 @@ def test_end_of_sentence():
     intxt = '{0!s}{1!s}'
 
     def check(u, p):
-        eq_(out.format(u, p),
-            linkify(intxt.format(u, p)))
+        assert out.format(u, p) == \
+            linkify(intxt.format(u, p))
 
     tests = (
         ('example.com', '.'),
@@ -349,15 +353,16 @@ def test_end_of_sentence():
 
 def test_end_of_clause():
     """example.com/foo, shouldn't include the ,"""
-    eq_('<a href="http://ex.com/foo" rel="nofollow">ex.com/foo</a>, bar',
-        linkify('ex.com/foo, bar'))
+    assert '<a href="http://ex.com/foo" rel="nofollow">ex.com/foo'
+    '</a>, bar' == \
+        linkify('ex.com/foo, bar')
 
 
 def test_sarcasm():
     """Jokes should crash.<sarcasm/>"""
     dirty = 'Yeah right <sarcasm/>'
     clean = 'Yeah right &lt;sarcasm/&gt;'
-    eq_(clean, linkify(dirty))
+    assert clean == linkify(dirty)
 
 
 def test_wrapping_parentheses():
@@ -395,7 +400,7 @@ def test_wrapping_parentheses():
     )
 
     def check(test, expected_output):
-        eq_(out.format(*expected_output), linkify(test))
+        assert out.format(*expected_output) == linkify(test)
 
     for test, expected_output in tests:
         yield check, test, expected_output
@@ -403,7 +408,7 @@ def test_wrapping_parentheses():
 
 def test_parentheses_with_removing():
     expect = '(test.py)'
-    eq_(expect, linkify(expect, callbacks=[lambda *a: None]))
+    assert expect == linkify(expect, callbacks=[lambda *a: None])
 
 
 def test_ports():
@@ -418,8 +423,8 @@ def test_ports():
 
     def check(test, output):
         out = '<a href="{0}" rel="nofollow">{0}</a>{1}'
-        eq_(out.format(*output),
-            linkify(test))
+        assert out.format(*output) == \
+            linkify(test)
 
     for test, output in tests:
         yield check, test, output
@@ -428,21 +433,22 @@ def test_ports():
 def test_tokenizer():
     """Linkify doesn't always have to sanitize."""
     raw = '<em>test<x></x></em>'
-    eq_('<em>test&lt;x&gt;&lt;/x&gt;</em>', linkify(raw))
-    eq_(raw, linkify(raw, tokenizer=HTMLTokenizer))
+    assert '<em>test&lt;x&gt;&lt;/x&gt;</em>' == linkify(raw)
+    assert raw == linkify(raw, tokenizer=HTMLTokenizer)
 
 
 def test_ignore_bad_protocols():
-    eq_('foohttp://bar',
-        linkify('foohttp://bar'))
-    eq_('fohttp://<a href="http://exampl.com" rel="nofollow">exampl.com</a>',
-        linkify('fohttp://exampl.com'))
+    assert 'foohttp://bar' == \
+        linkify('foohttp://bar')
+    assert 'fohttp://<a href="http://exampl.com" rel="nofollow">exampl.com'
+    '</a>' == \
+        linkify('fohttp://exampl.com')
 
 
 def test_max_recursion_depth():
     """If we hit the max recursion depth, just return the string."""
     test = '<em>' * 2000 + 'foo' + '</em>' * 2000
-    eq_(test, linkify(test))
+    assert test == linkify(test)
 
 
 def test_link_emails_and_urls():
@@ -450,27 +456,28 @@ def test_link_emails_and_urls():
     output = ('<a href="http://example.com" rel="nofollow">'
               'http://example.com</a> <a href="mailto:person@example.com">'
               'person@example.com</a>')
-    eq_(output, linkify('http://example.com person@example.com',
-                        parse_email=True))
+    assert output == linkify('http://example.com person@example.com',
+                             parse_email=True)
 
 
 def test_links_case_insensitive():
     """Protocols and domain names are case insensitive."""
     expect = ('<a href="HTTP://EXAMPLE.COM" rel="nofollow">'
               'HTTP://EXAMPLE.COM</a>')
-    eq_(expect, linkify('HTTP://EXAMPLE.COM'))
+    assert expect == linkify('HTTP://EXAMPLE.COM')
 
 
 def test_elements_inside_links():
-    eq_('<a href="#" rel="nofollow">hello<br></a>',
-        linkify('<a href="#">hello<br></a>'))
+    assert '<a href="#" rel="nofollow">hello<br></a>' == \
+        linkify('<a href="#">hello<br></a>')
 
-    eq_('<a href="#" rel="nofollow"><strong>bold</strong> hello<br></a>',
-        linkify('<a href="#"><strong>bold</strong> hello<br></a>'))
+    assert '<a href="#" rel="nofollow"><strong>bold</strong> hello'
+    '<br></a>' == \
+        linkify('<a href="#"><strong>bold</strong> hello<br></a>')
 
 
 def test_remove_first_childlink():
     expect = '<p>something</p>'
     callbacks = [lambda *a: None]
-    eq_(expect,
-        linkify('<p><a href="/foo">something</a></p>', callbacks=callbacks))
+    assert expect == \
+        linkify('<p><a href="/foo">something</a></p>', callbacks=callbacks)

--- a/bleach/tests/test_security.py
+++ b/bleach/tests/test_security.py
@@ -1,90 +1,90 @@
 """More advanced security tests"""
 
-from nose.tools import eq_
-
 from bleach import clean
 
 
 def test_nested_script_tag():
-    eq_('&lt;&lt;script&gt;script&gt;evil()&lt;&lt;/script&gt;/script&gt;',
-        clean('<<script>script>evil()<</script>/script>'))
-    eq_('&lt;&lt;x&gt;script&gt;evil()&lt;&lt;/x&gt;/script&gt;',
-        clean('<<x>script>evil()<</x>/script>'))
+    assert '&lt;&lt;script&gt;script&gt;evil()'
+    '&lt;&lt;/script&gt;/script&gt;' == \
+        clean('<<script>script>evil()<</script>/script>')
+    assert '&lt;&lt;x&gt;script&gt;evil()&lt;&lt;/x&gt;/script&gt;' == \
+        clean('<<x>script>evil()<</x>/script>')
 
 
 def test_nested_script_tag_r():
-    eq_('&lt;script&lt;script&gt;&gt;evil()&lt;/script&lt;&gt;&gt;',
-        clean('<script<script>>evil()</script</script>>'))
+    assert '&lt;script&lt;script&gt;&gt;evil()&lt;/script&lt;&gt;&gt;' == \
+        clean('<script<script>>evil()</script</script>>')
 
 
 def test_invalid_attr():
     IMG = ['img', ]
     IMG_ATTR = ['src']
 
-    eq_('<a href="test">test</a>',
-        clean('<a onclick="evil" href="test">test</a>'))
-    eq_('<img src="test">',
+    assert '<a href="test">test</a>' == \
+        clean('<a onclick="evil" href="test">test</a>')
+    assert '<img src="test">' == \
         clean('<img onclick="evil" src="test" />',
-              tags=IMG, attributes=IMG_ATTR))
-    eq_('<img src="test">',
+              tags=IMG, attributes=IMG_ATTR)
+    assert '<img src="test">' == \
         clean('<img href="invalid" src="test" />',
-              tags=IMG, attributes=IMG_ATTR))
+              tags=IMG, attributes=IMG_ATTR)
 
 
 def test_unquoted_attr():
-    eq_('<abbr title="mytitle">myabbr</abbr>',
-        clean('<abbr title=mytitle>myabbr</abbr>'))
+    assert '<abbr title="mytitle">myabbr</abbr>' == \
+        clean('<abbr title=mytitle>myabbr</abbr>')
 
 
 def test_unquoted_event_handler():
-    eq_('<a href="http://xx.com">xx.com</a>',
-        clean('<a href="http://xx.com" onclick=foo()>xx.com</a>'))
+    assert '<a href="http://xx.com">xx.com</a>' == \
+        clean('<a href="http://xx.com" onclick=foo()>xx.com</a>')
 
 
 def test_invalid_attr_value():
-    eq_('&lt;img src="javascript:alert(\'XSS\');"&gt;',
-        clean('<img src="javascript:alert(\'XSS\');">'))
+    assert '&lt;img src="javascript:alert(\'XSS\');"&gt;' == \
+        clean('<img src="javascript:alert(\'XSS\');">')
 
 
 def test_invalid_href_attr():
-    eq_('<a>xss</a>',
-        clean('<a href="javascript:alert(\'XSS\')">xss</a>'))
+    assert '<a>xss</a>' == \
+        clean('<a href="javascript:alert(\'XSS\')">xss</a>')
 
 
 def test_invalid_filter_attr():
     IMG = ['img', ]
     IMG_ATTR = {'img': lambda n, v: n == 'src' and v == "http://example.com/"}
 
-    eq_('<img src="http://example.com/">',
+    assert '<img src="http://example.com/">' == \
         clean('<img onclick="evil" src="http://example.com/" />',
-              tags=IMG, attributes=IMG_ATTR))
+              tags=IMG, attributes=IMG_ATTR)
 
-    eq_('<img>', clean('<img onclick="evil" src="http://badhost.com/" />',
-                       tags=IMG, attributes=IMG_ATTR))
+    assert '<img>' == clean('<img onclick="evil" src="http://badhost.com/" />',
+                            tags=IMG, attributes=IMG_ATTR)
 
 
 def test_invalid_tag_char():
-    eq_('&lt;script xss="" src="http://xx.com/xss.js"&gt;&lt;/script&gt;',
-        clean('<script/xss src="http://xx.com/xss.js"></script>'))
-    eq_('&lt;script src="http://xx.com/xss.js"&gt;&lt;/script&gt;',
-        clean('<script/src="http://xx.com/xss.js"></script>'))
+    assert '&lt;script xss="" '
+    'src="http://xx.com/xss.js"&gt;&lt;/script&gt;' == \
+        clean('<script/xss src="http://xx.com/xss.js"></script>')
+    assert '&lt;script src="http://xx.com/xss.js"&gt;&lt;/script&gt;' == \
+        clean('<script/src="http://xx.com/xss.js"></script>')
 
 
 def test_unclosed_tag():
-    eq_('&lt;script src="http://xx.com/xss.js&amp;lt;b"&gt;',
-        clean('<script src=http://xx.com/xss.js<b>'))
-    eq_('&lt;script src="http://xx.com/xss.js" &lt;b=""&gt;',
-        clean('<script src="http://xx.com/xss.js"<b>'))
-    eq_('&lt;script src="http://xx.com/xss.js" &lt;b=""&gt;',
-        clean('<script src="http://xx.com/xss.js" <b>'))
+    assert '&lt;script src="http://xx.com/xss.js&amp;lt;b"&gt;' == \
+        clean('<script src=http://xx.com/xss.js<b>')
+    assert '&lt;script src="http://xx.com/xss.js" &lt;b=""&gt;' == \
+        clean('<script src="http://xx.com/xss.js"<b>')
+    assert '&lt;script src="http://xx.com/xss.js" &lt;b=""&gt;' == \
+        clean('<script src="http://xx.com/xss.js" <b>')
 
 
 def test_strip():
     """Using strip=True shouldn't result in malicious content."""
     s = '<scri<script>pt>alert(1)</scr</script>ipt>'
-    eq_('pt&gt;alert(1)ipt&gt;', clean(s, strip=True))
+    assert 'pt&gt;alert(1)ipt&gt;' == clean(s, strip=True)
     s = '<scri<scri<script>pt>pt>alert(1)</script>'
-    eq_('pt&gt;pt&gt;alert(1)', clean(s, strip=True))
+    assert 'pt&gt;pt&gt;alert(1)' == clean(s, strip=True)
 
 
 def test_nasty():
@@ -94,7 +94,7 @@ def test_nasty():
     expect = ('&lt;scr&lt;script&gt;&lt;/script&gt;ipt type="text/javascript"'
               '&gt;alert("foo");&lt;/script&gt;script&lt;del&gt;&lt;/del&gt;'
               '&gt;')
-    eq_(expect, clean(test))
+    assert expect == clean(test)
 
 
 def test_poster_attribute():
@@ -103,10 +103,10 @@ def test_poster_attribute():
     attrs = {'video': ['poster']}
     test = '<video poster="javascript:alert(1)"></video>'
     expect = '<video></video>'
-    eq_(expect, clean(test, tags=tags, attributes=attrs))
+    assert expect == clean(test, tags=tags, attributes=attrs)
     ok = '<video poster="/foo.png"></video>'
-    eq_(ok, clean(ok, tags=tags, attributes=attrs))
+    assert ok == clean(ok, tags=tags, attributes=attrs)
 
 
 def test_feed_protocol():
-    eq_('<a>foo</a>', clean('<a href="feed:file:///tmp/foo">foo</a>'))
+    assert '<a>foo</a>' == clean('<a href="feed:file:///tmp/foo">foo</a>')

--- a/bleach/tests/test_unicode.py
+++ b/bleach/tests/test_unicode.py
@@ -1,31 +1,30 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from nose.tools import eq_
 
 from bleach import clean, linkify
 from bleach.tests.tools import in_
 
 
 def test_japanese_safe_simple():
-    eq_('ヘルプとチュートリアル', clean('ヘルプとチュートリアル'))
-    eq_('ヘルプとチュートリアル', linkify('ヘルプとチュートリアル'))
+    assert 'ヘルプとチュートリアル' == clean('ヘルプとチュートリアル')
+    assert 'ヘルプとチュートリアル' == linkify('ヘルプとチュートリアル')
 
 
 def test_japanese_strip():
-    eq_('<em>ヘルプとチュートリアル</em>',
-        clean('<em>ヘルプとチュートリアル</em>'))
-    eq_('&lt;span&gt;ヘルプとチュートリアル&lt;/span&gt;',
-        clean('<span>ヘルプとチュートリアル</span>'))
+    assert '<em>ヘルプとチュートリアル</em>' == \
+        clean('<em>ヘルプとチュートリアル</em>')
+    assert '&lt;span&gt;ヘルプとチュートリアル&lt;/span&gt;' == \
+        clean('<span>ヘルプとチュートリアル</span>')
 
 
 def test_russian_simple():
-    eq_('Домашняя', clean('Домашняя'))
-    eq_('Домашняя', linkify('Домашняя'))
+    assert 'Домашняя' == clean('Домашняя')
+    assert 'Домашняя' == linkify('Домашняя')
 
 
 def test_mixed():
-    eq_('Домашняяヘルプとチュートリアル',
-        clean('Домашняяヘルプとチュートリアル'))
+    assert 'Домашняяヘルプとチュートリアル' == \
+        clean('Домашняяヘルプとチュートリアル')
 
 
 def test_mixed_linkify():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six
 html5lib>=0.999,<0.99999999
 
 # Requirements to run the test suite:
-nose
+pytest>=3.0.3,<4.0
 flake8
 tox
 

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,8 @@ setup(
     zip_safe=False,
     install_requires=install_requires,
     tests_require=[
-        'nose>=1.3',
+        'pytest>=3.0.3,<4.0',
     ],
-    test_suite='nose.collector',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@
 envlist = py26, py27, py32, py33, py34, py35, pypy
 
 [testenv]
-commands = nosetests {posargs:-v}
+commands = py.test {posargs:-v}
 deps =
     six
     html5lib==0.999
-    nose
+    py.test


### PR DESCRIPTION
ref #204 
#### Move to unittests to pytest

Flake8 on python2.6 is not supported anymore as detailed here:
https://gitlab.com/pycqa/flake8/issues/187

Tests pass except:
- flake8 on python 2.6
- string formatting syntax on python 3.2 (can't find the documentation anymore of python 3.2). Does bleach wants to still support python 3.2?

https://travis-ci.org/mozilla/bleach/builds/165500484
