### PR TITLE
Stop linkify from hanging on weird email input - should fix #200

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -246,6 +246,8 @@ def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False,
         current_child = -1
         # start at -1 to process the parent first
         while current_child < len(tree):
+            if not tree.text:
+                return
             if current_child < 0:
                 node = tree
                 if parse_text and node.text:


### PR DESCRIPTION
I fixed the hanging issue, but the output looks...wrong:

``` html
<a href="mailto:an@email.com">an@email.com</a>&lt;mailto:&lt;a href="mailto:an@email.com"&gt;an@email.com&gt;
```

And that renders (GitHub linkified the second and third addresses so ignore those) as:

> <a href="mailto:an@email.com">an@email.com</a>&lt;mailto:&lt;a href="mailto:an@email.com"&gt;an@email.com&gt;

Flipping `parse_email` to `False` seems to return something more sensible:

``` html
an@email.com&lt;<a href="mailto:an@email.com">mailto:an@email.com</a>&gt;
```

because that renders (GitHub linkified the first address so ignore that) as:

> an@email.com&lt;<a href="mailto:an@email.com">mailto:an@email.com</a>&gt;

But doing that prevents `linkify` from hanging to begin with.

I can't tell if this is the intended behavior or not, but it's not hanging anymore.

@willkg I guess merge if you're happy with this. If not, let me know what the expected output is in each case.
