### PR TITLE
Use ASCII digits in port number parsing

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -71,7 +71,7 @@ PROTOCOLS = HTMLSanitizer.acceptable_protocols
 url_re = re.compile(
     r"""\(*  # Match any opening parentheses.
     \b(?<![@.])(?:(?:{0}):/{{0,3}}(?:(?:\w+:)?\w+@)?)?  # http://
-    ([\w-]+\.)+(?:{1})(?:\:\d+)?(?!\.\w)\b   # xx.yy.tld(:##)?
+    ([\w-]+\.)+(?:{1})(?:\:[0-9]+)?(?!\.\w)\b   # xx.yy.tld(:##)?
     (?:[/?][^\s\{{\}}\|\\\^\[\]`<>"]*)?
         # /path/zz (excluding "unsafe" chars from RFC 1738,
         # except for # and ~, which happen in practice)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -473,11 +473,18 @@ def test_parentheses_with_removing():
 
 
 @pytest.mark.parametrize('data,expected_data', [
+    # Test valid ports
     ('http://foo.com:8000', ('http://foo.com:8000', '')),
     ('http://foo.com:8000/', ('http://foo.com:8000/', '')),
+
+    # Test non ports
     ('http://bar.com:xkcd', ('http://bar.com', ':xkcd')),
     ('http://foo.com:81/bar', ('http://foo.com:81/bar', '')),
     ('http://foo.com:', ('http://foo.com', ':')),
+
+    # Test non-ascii ports
+    ('http://foo.com:\u0663\u0669/', ('http://foo.com', ':\u0663\u0669/')),
+    ('http://foo.com:\U0001d7e0\U0001d7d8/', ('http://foo.com', ':\U0001d7e0\U0001d7d8/')),
 ])
 def test_ports(data, expected_data):
     """URLs can contain port numbers."""


### PR DESCRIPTION
This fixes PR #207 which broke when I converted to py.test.