### PR TITLE
Allow travis to fail with Python 2.6 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ python:
 - "3.4"
 - "3.5"
 - "pypy"
+matrix:
+  allow_failures:
+  - python: "2.6"
+  - python: "3.2"
 install:
 - pip install -r requirements.txt
 script:


### PR DESCRIPTION
It's failing now with Python 2.6 because flake8 doesn't work with Python
2.6. It's failing with Python 3.2 because py.test doesn't work with
Python 3.2.

I'm not quite ready to drop support for both of them, though. So for
now, let's allow the failures.