### PR TITLE
Fix test_idempotent to not sometimes fail

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -198,7 +198,7 @@ def test_idempotent():
         '<span>invalid &amp; </span> &lt; extra <a href="http://link.com" rel="nofollow">http://link.com</a><em></em>'
     )
     linked = bleach.linkify(dirty)
-    assert bleach.linkify(linked) == possible_outs
+    assert bleach.linkify(linked) in possible_outs
 
 
 def test_rel_already_there():

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -193,8 +193,12 @@ def test_idempotent():
     clean = bleach.clean(dirty)
     assert bleach.clean(clean) == clean
 
+    possible_outs = (
+        '<span>invalid &amp; </span> &lt; extra <a rel="nofollow" href="http://link.com">http://link.com</a><em></em>',
+        '<span>invalid &amp; </span> &lt; extra <a href="http://link.com" rel="nofollow">http://link.com</a><em></em>'
+    )
     linked = bleach.linkify(dirty)
-    assert bleach.linkify(linked) == linked
+    assert bleach.linkify(linked) == possible_outs
 
 
 def test_rel_already_there():


### PR DESCRIPTION
linkify can return text with html attributes in a different order
depending on how the attributes come out of the attrs dict. Because of
that, there are several possible outcomes.

This fixes the linkify test to accept both of them.

Fixes #161