### PR TITLE
Fix linkify with node tails

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Version 1.5? (in progress)
   Lorenz Schori! #219
 - linkify: Fix linkification of non-ascii ports. Thank you Alexandre, Macabies!
   #207
+- linkify: Fix linkify inappropriately removing node tails when dropping nodes.
+  #132
 - Fixed a test that failed periodically. #161
 - Switched from nose to py.test. #204
 - Add test matrix for all supported Python and html5lib versions. #230

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -559,3 +559,12 @@ def test_remove_first_childlink():
         linkify('<p><a href="/foo">something</a></p>', callbacks=callbacks) ==
         '<p>something</p>'
     )
+
+
+def test_drop_link_tags():
+    """Verify that dropping link tags *just* drops the tag and not the content"""
+    html = """first <a href="http://example.com/1/">second</a> third <a href="http://example.com/2/">fourth</a> fifth"""
+    assert (
+        linkify(html, callbacks=[lambda attrs, new: None]) ==
+        'first second third fourth fifth'
+    )


### PR DESCRIPTION
When linkify is removing nodes, it wasn't capturing the node tail text.
Thus it'd lose text it shouldn't have been losing.

Fixes #132