### PR TITLE
Support linkify() callbacks to replace attributes for tags other than <a>

### DIFF
--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -568,3 +568,14 @@ def test_drop_link_tags():
         linkify(html, callbacks=[lambda attrs, new: None]) ==
         'first second third fourth fifth'
     )
+
+
+def test_linkify_replace_img_src():
+    html = '<img src="https://example.com/img.jpg">'
+
+    def replace_img_src(attrs):
+        attrs['src'] = 'https://proxy.example.com?url={}'.format(attrs['src'])
+        return attrs
+
+    replaced = linkify(html, tag_callbacks={'img': [replace_img_src]})
+    assert replaced == '<img src="https://proxy.example.com?url=https://example.com/img.jpg">'


### PR DESCRIPTION
This will allow, for example, to replace URLs in <img src="">

See mozilla/bleach#76

In the long term, it might be worth refactoring linkify() a bit, to reduce complexity in that single function and make it more extensible instead.. but I think this should do for now. Comments?

Also, happy new year! 🎉 