### PR TITLE
Refactor allow_token

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -84,51 +84,60 @@ class BleachSanitizerFilter(sanitizer.Filter):
             for namespaced_name, val in token['data'].items():
                 namespace, name = namespaced_name
 
+                # See if we should dump the attribute
                 if callable(allowed_attributes):
-                    if allowed_attributes(name, val):
-                        attrs[namespaced_name] = val
+                    if not allowed_attributes(name, val):
+                        # DROP!
+                        continue
 
-                elif name in allowed_attributes:
-                    attrs[namespaced_name] = val
-
-            # Handle attributes that have uri values
-            for attr in self.attr_val_is_uri:
-                if attr not in attrs:
+                elif name not in allowed_attributes:
+                    # DROP!
                     continue
 
-                val_unescaped = re.sub("[`\000-\040\177-\240\s]+", '',
-                                       unescape(attrs[attr])).lower()
+                # Look at attributes that have uri values
+                if namespaced_name in self.attr_val_is_uri:
+                    val_unescaped = re.sub(
+                        "[`\000-\040\177-\240\s]+",
+                        '',
+                        unescape(val)).lower()
 
-                # Remove replacement characters from unescaped characters.
-                val_unescaped = val_unescaped.replace("\ufffd", "")
+                    # Remove replacement characters from unescaped characters.
+                    val_unescaped = val_unescaped.replace("\ufffd", "")
 
-                if (re.match(r'^[a-z0-9][-+.a-z0-9]*:', val_unescaped) and
-                        (val_unescaped.split(':')[0] not in self.allowed_protocols)):
-                    # It has a protocol, but it's not allowed--so drop it
-                    del attrs[attr]
+                    # Drop attributes with uri values that have protocols that
+                    # aren't allowed
+                    if (re.match(r'^[a-z0-9][-+.a-z0-9]*:', val_unescaped) and
+                            (val_unescaped.split(':')[0] not in self.allowed_protocols)):
+                        # DROP!
+                        continue
 
-            # Drop values in svg attrs with non-local IRIs
-            for attr in self.svg_attr_val_allows_ref:
-                if attr in attrs:
+                # Drop values in svg attrs with non-local IRIs
+                if namespaced_name in self.svg_attr_val_allows_ref:
                     new_val = re.sub(r'url\s*\(\s*[^#\s][^)]+?\)',
                                      ' ',
-                                     unescape(attrs[attr]))
+                                     unescape(val))
                     new_val = new_val.strip()
                     if not new_val:
-                        del attrs[attr]
+                        # DROP!
+                        continue
+
                     else:
-                        attrs[attr] = new_val
+                        # Replace the val with the unescaped version because
+                        # it's a iri
+                        val = new_val
 
-            # Drop href and xlink:href attr for svg elements with non-local IRIs
-            if (None, token['name']) in self.svg_allow_local_href:
-                for href_attr in [(None, 'href'), (namespaces['xlink'], 'href')]:
-                    if href_attr in attrs:
-                        if re.search(r'^\s*[^#\s]', attrs[href_attr]):
-                            del attrs[href_attr]
+                # Drop href and xlink:href attr for svg elements with non-local IRIs
+                if (None, token['name']) in self.svg_allow_local_href:
+                    if namespaced_name in [(None, 'href'), (namespaces['xlink'], 'href')]:
+                        if re.search(r'^\s*[^#\s]', val):
+                            continue
 
-            # Sanitize css in style attribute
-            if (None, u'style') in attrs:
-                attrs[(None, u'style')] = self.sanitize_css(attrs[(None, u'style')])
+                # If it's a style attribute, sanitize it
+                if namespaced_name == (None, u'style'):
+                    val = self.sanitize_css(val)
+
+                # At this point, we want to keep the attribute, so add it in
+                attrs[namespaced_name] = val
 
             # Alphabetize attributes
             token['data'] = OrderedDict(

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -141,7 +141,7 @@ class BleachSanitizerFilter(sanitizer.Filter):
 
             # Alphabetize attributes
             token['data'] = OrderedDict(
-                [(key, val) for key, val in sorted(attrs.items(), key=_attr_key)]
+                [(k, v) for k, v in sorted(attrs.items(), key=_attr_key)]
             )
         return token
 


### PR DESCRIPTION
This redoes the innards of allow_token so that it's a single loop across all the
attributes in a token rather than a bunch of little passes.

This has less looping, so theoretically it's more optimal, but I didn't spend
any time testing that theory.