### PR TITLE
Implement ability to use Filters in cleaning

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -16,7 +16,6 @@ def _attr_key(attr):
 
     """
     key = (attr[0][0] or ''), attr[0][1]
-    print(key)
     return key
 
 


### PR DESCRIPTION
This lets users extend cleaning more easily by specifying an html5lib Filter.

Fixes #58.