### PR TITLE
Restructure linkify; clean up __init__; update docs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,7 +17,7 @@ Version 2.0 (in development)
 
 * ``bleach.clean`` and friends were rewritten
 
-  ``clean`` is now implemented as an html5lib Filter and happens at a different
+  ``clean`` was reimplemented as an html5lib filter and happens at a different
   step in the HTML parsing -> traversing -> serializing process. Because of
   that, there are some differences in clean's output as compared with previous
   versions.
@@ -43,11 +43,14 @@ Version 2.0 (in development)
   Now it's more like this::
 
       def check_protocol(attrs, is_new):
-          if not attrs.get((None, 'href'), '').startswith(('http:', 'https:')):
+          if not attrs.get((None, u'href'), u'').startswith(('http:', 'https:')):
               #            ^^^^^^^^^^^^^^
               return None
           return attrs
 
+  Further, you need to make sure you're always using unicode values. If you
+  don't then html5lib will raise an assertion error that the value is not
+  unicode.
 
 **Changes**
 
@@ -55,17 +58,19 @@ Version 2.0 (in development)
 
 * Supports html5lib >= 0.99999999 (8 9s).
 
-* There's a ``bleach.Cleaner`` class that you can instantiate with your
-  favorite clean settings and reuse it.
+* There's a ``bleach.sanitizer.Cleaner`` class that you can instantiate with your
+  favorite clean settings for easy reuse.
 
-* There's a ``bleach.linkifier.LinkifyFilter`` which is an htm5lib Filter.
+* There's a ``bleach.linkifier.Linker`` class that you can instantiate with your
+  favorite linkify settings for easy reuse.
 
-* You can pass ``bleach.linkifier.LinkifyFilter`` as a Filter to
-  ``bleach.Cleaner`` allowing you to clean and linkify in one pass.
+* There's a ``bleach.linkifier.LinkifyFilter`` which is an htm5lib filter that
+  you can pass as a filter to ``bleach.Cleaner`` allowing you to clean and
+  linkify in one pass.
 
-* Lots of bug fixes.
+* Tons of bug fixes.
 
-* Test cleanup.
+* Cleaned up tests.
 
 * Documentation fixes.
 

--- a/CHANGES
+++ b/CHANGES
@@ -44,7 +44,7 @@ Version 2.0 (in development)
 
       def check_protocol(attrs, is_new):
           if not attrs.get((None, u'href'), u'').startswith(('http:', 'https:')):
-              #            ^^^^^^^^^^^^^^
+              #            ^^^^^^^^^^^^^^^
               return None
           return attrs
 
@@ -65,8 +65,8 @@ Version 2.0 (in development)
   favorite linkify settings for easy reuse.
 
 * There's a ``bleach.linkifier.LinkifyFilter`` which is an htm5lib filter that
-  you can pass as a filter to ``bleach.Cleaner`` allowing you to clean and
-  linkify in one pass.
+  you can pass as a filter to ``bleach.sanitizer.Cleaner`` allowing you to clean
+  and linkify in one pass.
 
 * Tons of bug fixes.
 

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -1,169 +1,28 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import logging
-import re
 
-import html5lib
-from html5lib.filters import sanitizer
-from html5lib.filters.sanitizer import allowed_protocols
-from html5lib.serializer import HTMLSerializer
-
-from bleach import callbacks as linkify_callbacks
-from bleach.encoding import force_unicode
-from bleach.linkifier import LinkifyFilter
-from bleach.sanitizer import BleachSanitizerFilter
+from bleach.linkifier import (
+    DEFAULT_CALLBACKS,
+    Linker,
+    LinkifyFilter,
+)
+from bleach.sanitizer import (
+    ALLOWED_ATTRIBUTES,
+    ALLOWED_PROTOCOLS,
+    ALLOWED_STYLES,
+    ALLOWED_TAGS,
+    BleachSanitizerFilter,
+    Cleaner,
+)
 from bleach.version import __version__, VERSION # flake8: noqa
 
-__all__ = ['Cleaner', 'clean', 'linkify']
-
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
-
-ALLOWED_TAGS = [
-    'a',
-    'abbr',
-    'acronym',
-    'b',
-    'blockquote',
-    'code',
-    'em',
-    'i',
-    'li',
-    'ol',
-    'strong',
-    'ul',
-]
-
-ALLOWED_ATTRIBUTES = {
-    'a': ['href', 'title'],
-    'abbr': ['title'],
-    'acronym': ['title'],
-}
-
-ALLOWED_STYLES = []
-
-ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']
-
-ETREE_TAG = lambda x: "".join(['{http://www.w3.org/1999/xhtml}', x])
-# a simple routine that returns the tag name with the namespace prefix
-# as returned by etree's Element.tag attribute
-
-DEFAULT_CALLBACKS = [linkify_callbacks.nofollow]
-
-
-class Cleaner(object):
-    """Cleaner for cleaning HTML fragments of malicious content
-
-    This cleaner is a security-focused function whose sole purpose is to remove
-    malicious content from a string such that it can be displayed as content in
-    a web page.
-
-    This cleaner is not designed to use to transform content to be used in
-    non-web-page contexts.
-
-    To use::
-
-        from bleach import Cleaner
-
-        cleaner = Cleaner()
-
-        for text in all_the_yucky_things:
-            sanitized = cleaner.clean(text)
-
-    """
-
-    def __init__(self, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-                 styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
-                 strip_comments=True, filters=None):
-        """Initializes a Cleaner
-
-        :arg tags: whitelist of allowed tags; defaults to
-            ``bleach.ALLOWED_TAGS``
-
-        :arg attributes: whitelist of allowed attributes; defaults to
-            ``bleach.ALLOWED_ATTRIBUTES``
-
-        :arg styles: whitelist of allowed css; defaults to
-            ``bleach.ALLOWED_STYLES``
-
-        :arg protocols: whitelist of allowed protocols for links; defaults
-            to ``bleach.ALLOWED_PROTOCOLS``
-
-        :arg strip: whether or not to strip disallowed elements
-
-        :arg strip_comments: whether or not to strip HTML comments
-
-        :arg filters: list of html5lib Filter classes to pass streamed content through
-
-            See http://html5lib.readthedocs.io/en/latest/movingparts.html#filters
-
-            .. Warning::
-
-               Using filters changes the output of ``bleach.Cleaner.clean``.
-               Make sure the way the filters change the output are secure.
-
-        """
-        self.tags = tags
-        self.attributes = attributes
-        self.styles = styles
-        self.protocols = protocols
-        self.strip = strip
-        self.strip_comments = strip_comments
-        self.filters = filters or []
-
-        self.parser = html5lib.HTMLParser(namespaceHTMLElements=False)
-        self.walker = html5lib.getTreeWalker('etree')
-        self.serializer = HTMLSerializer(
-            quote_attr_values='always',
-            omit_optional_tags=False,
-
-            # Bleach has its own sanitizer, so don't use the html5lib one
-            sanitize=False,
-
-            # Bleach sanitizer alphabetizes already, so don't use the html5lib one
-            alphabetical_attributes=False,
-        )
-
-    def clean(self, text):
-        """Cleans text and returns sanitized result as unicode
-
-        :arg str text: text to be cleaned
-
-        :returns: sanitized text as unicode
-
-        """
-        if not text:
-            return u''
-
-        text = force_unicode(text)
-
-        dom = self.parser.parseFragment(text)
-        filtered = BleachSanitizerFilter(
-            source=self.walker(dom),
-
-            # Bleach-sanitizer-specific things
-            allowed_attributes_map=self.attributes,
-            strip_disallowed_elements=self.strip,
-            strip_html_comments=self.strip_comments,
-
-            # html5lib-sanitizer things
-            allowed_elements=self.tags,
-            allowed_css_properties=self.styles,
-            allowed_protocols=self.protocols,
-            allowed_svg_properties=[],
-        )
-
-        # Apply any filters after the BleachSanitizerFilter
-        for filter_class in self.filters:
-            filtered = filter_class(source=filtered)
-
-        return self.serializer.render(filtered)
+__all__ = ['clean', 'linkify']
 
 
 def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
           styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
-          strip_comments=True, filters=None):
+          strip_comments=True):
     """Clean an HTML fragment of malicious content and return it
 
     This function is a security-focused function whose sole purpose is to
@@ -182,36 +41,27 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
     .. Note::
 
-       If you're cleaning a lot of text and passing the same argument
-       values, consider caching a ``Cleaner`` instance.
+       If you're cleaning a lot of text and passing the same argument values or
+       you want more configurability, consider using a
+       :py:class:`bleach.sanitizer.Cleaner` instance.
 
-    :arg text: the text to clean
+    :arg str text: the text to clean
 
-    :arg tags: whitelist of allowed tags; defaults to
+    :arg list tags: whitelist of allowed tags; defaults to
         ``bleach.ALLOWED_TAGS``
 
-    :arg attributes: whitelist of allowed attributes; defaults to
+    :arg dict attributes: whitelist of allowed attributes; defaults to
         ``bleach.ALLOWED_ATTRIBUTES``
 
-    :arg styles: whitelist of allowed css; defaults to
+    :arg list styles: whitelist of allowed css; defaults to
         ``bleach.ALLOWED_STYLES``
 
-    :arg protocols: whitelist of allowed protocols for links; defaults
+    :arg list protocols: whitelist of allowed protocols for links; defaults
         to ``bleach.ALLOWED_PROTOCOLS``
 
-    :arg strip: whether or not to strip disallowed elements
+    :arg bool strip: whether or not to strip disallowed elements
 
-    :arg strip_comments: whether or not to strip HTML comments
-
-    :arg filters: list of html5lib Filter classes to pass streamed content through
-
-        See http://html5lib.readthedocs.io/en/latest/movingparts.html#filters
-
-        .. Warning::
-
-           Using filters changes the output of
-           ``bleach.Cleaner.clean``. Make sure the way the filters
-           change the output are secure.
+    :arg bool strip_comments: whether or not to strip HTML comments
 
     :returns: cleaned text as unicode
 
@@ -223,7 +73,6 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
         protocols=protocols,
         strip=strip,
         strip_comments=strip_comments,
-        filters=filters,
     )
     return cleaner.clean(text)
 
@@ -231,40 +80,42 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False, parse_email=False):
     """Convert URL-like strings in an HTML fragment to links
 
-    ``linkify()`` converts strings that look like URLs, domain names and email
+    This function converts strings that look like URLs, domain names and email
     addresses in text that may be an HTML fragment to links, while preserving:
 
     1. links already in the string
     2. urls found in attributes
     3. email addresses
 
-    ``linkify()`` does a best-effort approach and tries to recover from bad
+    linkify does a best-effort approach and tries to recover from bad
     situations due to crazy text.
 
+    .. Note::
+
+       If you're linking a lot of text and passing the same argument values or
+       you want more configurability, consider using a
+       :py:class:`bleach.linkifier.Linker` instance.
+
+    .. Note::
+
+       If you have text that you want to clean and then linkify, consider using
+       the :py:class:`bleach.linkifier.LinkifyFilter` as a filter in the clean
+       pass. That way you're not parsing the HTML twice.
+
+    :arg str text: the text to linkify
+
+    :arg list callbacks: list of callbacks to run when adjusting tag attributes
+
+    :arg bool skip_pre: whether or not to skip linkifying text in a ``pre`` tag
+
+    :arg bool parse_email: whether or not to linkify email addresses
+
+    :returns: linkified text as unicode
+
     """
-    parser = html5lib.HTMLParser(namespaceHTMLElements=False)
-    walker = html5lib.getTreeWalker('etree')
-    serializer = HTMLSerializer(
-        quote_attr_values='always',
-        omit_optional_tags=False,
-
-        # Bleach has its own sanitizer, so don't use the html5lib one
-        sanitize=False,
-
-        # Bleach sanitizer alphabetizes already, so don't use the html5lib one
-        alphabetical_attributes=False,
-    )
-
-    text = force_unicode(text)
-
-    if not text:
-        return u''
-
-    dom = parser.parseFragment(text)
-    filtered = LinkifyFilter(
-        source=walker(dom),
+    linker = Linker(
         callbacks=callbacks,
         skip_pre=skip_pre,
         parse_email=parse_email
     )
-    return serializer.render(filtered)
+    return linker.linkify(text)

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -36,10 +36,6 @@ ALLOWED_STYLES = []
 
 ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']
 
-ETREE_TAG = lambda x: "".join(['{http://www.w3.org/1999/xhtml}', x])
-# a simple routine that returns the tag name with the namespace prefix
-# as returned by etree's Element.tag attribute
-
 
 class Cleaner(object):
     """Cleaner for cleaning HTML fragments of malicious content
@@ -53,7 +49,7 @@ class Cleaner(object):
 
     To use::
 
-        from bleach import Cleaner
+        from bleach.sanitizer import Cleaner
 
         cleaner = Cleaner()
 

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -2,10 +2,152 @@ from __future__ import unicode_literals
 import re
 from xml.sax.saxutils import unescape
 
+import html5lib
 from html5lib.constants import namespaces
 from html5lib.filters import sanitizer
+from html5lib.serializer import HTMLSerializer
 
+from bleach.encoding import force_unicode
 from bleach.utils import alphabetize_attributes
+
+
+ALLOWED_TAGS = [
+    'a',
+    'abbr',
+    'acronym',
+    'b',
+    'blockquote',
+    'code',
+    'em',
+    'i',
+    'li',
+    'ol',
+    'strong',
+    'ul',
+]
+
+ALLOWED_ATTRIBUTES = {
+    'a': ['href', 'title'],
+    'abbr': ['title'],
+    'acronym': ['title'],
+}
+
+ALLOWED_STYLES = []
+
+ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']
+
+ETREE_TAG = lambda x: "".join(['{http://www.w3.org/1999/xhtml}', x])
+# a simple routine that returns the tag name with the namespace prefix
+# as returned by etree's Element.tag attribute
+
+
+class Cleaner(object):
+    """Cleaner for cleaning HTML fragments of malicious content
+
+    This cleaner is a security-focused function whose sole purpose is to remove
+    malicious content from a string such that it can be displayed as content in
+    a web page.
+
+    This cleaner is not designed to use to transform content to be used in
+    non-web-page contexts.
+
+    To use::
+
+        from bleach import Cleaner
+
+        cleaner = Cleaner()
+
+        for text in all_the_yucky_things:
+            sanitized = cleaner.clean(text)
+
+    """
+
+    def __init__(self, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
+                 styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
+                 strip_comments=True, filters=None):
+        """Initializes a Cleaner
+
+        :arg tags: whitelist of allowed tags; defaults to
+            ``bleach.ALLOWED_TAGS``
+
+        :arg attributes: whitelist of allowed attributes; defaults to
+            ``bleach.ALLOWED_ATTRIBUTES``
+
+        :arg styles: whitelist of allowed css; defaults to
+            ``bleach.ALLOWED_STYLES``
+
+        :arg protocols: whitelist of allowed protocols for links; defaults
+            to ``bleach.ALLOWED_PROTOCOLS``
+
+        :arg strip: whether or not to strip disallowed elements
+
+        :arg strip_comments: whether or not to strip HTML comments
+
+        :arg filters: list of html5lib Filter classes to pass streamed content through
+
+            See http://html5lib.readthedocs.io/en/latest/movingparts.html#filters
+
+            .. Warning::
+
+               Using filters changes the output of ``bleach.Cleaner.clean``.
+               Make sure the way the filters change the output are secure.
+
+        """
+        self.tags = tags
+        self.attributes = attributes
+        self.styles = styles
+        self.protocols = protocols
+        self.strip = strip
+        self.strip_comments = strip_comments
+        self.filters = filters or []
+
+        self.parser = html5lib.HTMLParser(namespaceHTMLElements=False)
+        self.walker = html5lib.getTreeWalker('etree')
+        self.serializer = HTMLSerializer(
+            quote_attr_values='always',
+            omit_optional_tags=False,
+
+            # Bleach has its own sanitizer, so don't use the html5lib one
+            sanitize=False,
+
+            # Bleach sanitizer alphabetizes already, so don't use the html5lib one
+            alphabetical_attributes=False,
+        )
+
+    def clean(self, text):
+        """Cleans text and returns sanitized result as unicode
+
+        :arg str text: text to be cleaned
+
+        :returns: sanitized text as unicode
+
+        """
+        if not text:
+            return u''
+
+        text = force_unicode(text)
+
+        dom = self.parser.parseFragment(text)
+        filtered = BleachSanitizerFilter(
+            source=self.walker(dom),
+
+            # Bleach-sanitizer-specific things
+            allowed_attributes_map=self.attributes,
+            strip_disallowed_elements=self.strip,
+            strip_html_comments=self.strip_comments,
+
+            # html5lib-sanitizer things
+            allowed_elements=self.tags,
+            allowed_css_properties=self.styles,
+            allowed_protocols=self.protocols,
+            allowed_svg_properties=[],
+        )
+
+        # Apply any filters after the BleachSanitizerFilter
+        for filter_class in self.filters:
+            filtered = filter_class(source=filtered)
+
+        return self.serializer.render(filtered)
 
 
 class BleachSanitizerFilter(sanitizer.Filter):

--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -214,6 +214,7 @@ whitelist and invalid markup. For example:
 
    >>> bleach.clean('<span>is not allowed</span>')
    u'&lt;span&gt;is not allowed&lt;/span&gt;'
+
    >>> bleach.clean('<b><span>is not allowed</span></b>', tags=['b'])
    u'<b>&lt;span&gt;is not allowed&lt;/span&gt;</b>'
 
@@ -227,6 +228,7 @@ If you would rather Bleach stripped this markup entirely, you can pass
 
    >>> bleach.clean('<span>is not allowed</span>', strip=True)
    u'is not allowed'
+
    >>> bleach.clean('<b><span>is not allowed</span></b>', tags=['b'], strip=True)
    u'<b>is not allowed</b>'
 
@@ -250,10 +252,20 @@ By default, Bleach will strip out HTML comments. To disable this behavior, set
    u'my<!-- commented --> html'
 
 
-html5lib Filters (``filters``)
-==============================
+Using ``bleach.sanitizer.Cleaner``
+==================================
 
-Bleach sanitizing is implemented as an html5lib Filter. The consequence of this
+If you're cleaning a lot of text or you need better control of things, you
+should create a :py:class:`bleach.sanitizer.Cleaner` instance.
+
+.. autoclass:: bleach.sanitizer.Cleaner
+   :members:
+
+
+html5lib Filters (``filters``)
+------------------------------
+
+Bleach sanitizing is implemented as an html5lib filter. The consequence of this
 is that we can pass the streamed content through additional specified filters
 after the :py:class:`bleach.sanitizer.BleachSanitizingFilter` filter has run.
 
@@ -267,7 +279,7 @@ Trivial Filter example:
 
 .. doctest::
 
-   >>> import bleach
+   >>> from bleach.sanitizer import Cleaner
    >>> from html5lib.filters.base import Filter
 
    >>> class MooFilter(Filter):
@@ -283,8 +295,9 @@ Trivial Filter example:
    ... }
    ...
    >>> TAGS = ['img']
+   >>> cleaner = Cleaner(tags=TAGS, attributes=ATTRS, filters=[MooFilter])
    >>> dirty = 'this is cute! <img src="http://example.com/puppy.jpg" rel="nofollow">'
-   >>> bleach.clean(dirty, tags=TAGS, attributes=ATTRS, filters=[MooFilter])
+   >>> cleaner.clean(dirty)
    u'this is cute! <img rel="moo" src="moo">'
 
 
@@ -294,20 +307,11 @@ Trivial Filter example:
    filter is applying maintain the safety guarantees of the output.
 
 
-Using ``bleach.Cleaner``
-========================
-
-If you're cleaning a lot of text, you might want to create a
-:py:class:`bleach.Cleaner` instance.
-
-.. autoclass:: bleach.Cleaner
-   :members:
-
-
 Using ``bleach.sanitizer.BleachSanitizerFilter``
 ================================================
 
-``bleach.clean`` creates a ``bleach.Cleaner`` which creates a
+``bleach.clean`` creates a ``bleach.sanitizer.Cleaner`` which creates a
 ``bleach.sanitizer.BleachSanitizerFilter`` which does the sanitizing work.
-``BleachSanitizerFilter`` is an html5lib Filter and can be used anywhere you can
-use an html5lib Filter.
+
+``BleachSanitizerFilter`` is an html5lib filter and can be used anywhere you can
+use an html5lib filter.

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -3,6 +3,7 @@ import pytest
 import six
 
 import bleach
+from bleach.sanitizer import Cleaner
 
 
 class TestClean:
@@ -291,8 +292,11 @@ class TestClean:
         }
         TAGS = ['img']
         dirty = 'this is cute! <img src="http://example.com/puppy.jpg" rel="nofollow">'
+
+        cleaner = Cleaner(tags=TAGS, attributes=ATTRS, filters=[MooFilter])
+
         assert (
-            bleach.clean(dirty, tags=TAGS, attributes=ATTRS, filters=[MooFilter]) ==
+            cleaner.clean(dirty) ==
             'this is cute! <img rel="moo" src="moo">'
         )
 
@@ -302,7 +306,7 @@ class TestCleaner:
         TAGS = ['span', 'br']
         ATTRS = {'span': ['style']}
 
-        cleaner = bleach.Cleaner(tags=TAGS, attributes=ATTRS)
+        cleaner = Cleaner(tags=TAGS, attributes=ATTRS)
 
         assert (
             cleaner.clean('a <br/><span style="color:red">test</span>') ==


### PR DESCRIPTION
This is a ton of changes all in one commit. Sorry.

* Restructures linkify so it mirrors clean. This has the nicety in that
  the two are parallel and can be used the same.
* Rework how url_re and email_re work so that it's possible to override
  them and/or provide your own list of allowed procotols and TLDs
* Overhaul the docs including converting linkify examples to doctest
* Update CHANGES