### PR TITLE
Change skip_pre to the more general skip_tags

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,23 @@ Version 2.0 (in development)
 
   All linkify filters will need to be updated.
 
+* ``bleach.linkify`` and friends had a ``skip_pre`` argument--that's been
+  replaced with a more general ``skip_tags`` argument.
+
+  Before, you might do::
+
+      bleach.linkify(some_text, skip_pre=True)
+
+  The equivalent with Bleach 2.0 is::
+
+      bleach.linkify(some_text, skip_tags=['pre'])
+
+  You can skip other tags, too, like ``style`` or ``script`` or other places
+  where you don't want linkification happening.
+
+  All uses of linkify that use ``skip_pre`` will need to be updated.
+
+
 **Changes**
 
 * Supports Python 3.6.

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Bleach
 .. image:: https://badge.fury.io/py/bleach.svg
    :target: http://badge.fury.io/py/bleach
 
-Bleach is a whitelist-based HTML sanitizing library that escapes or strips
+Bleach is a allowed-list-based HTML sanitizing library that escapes or strips
 markup and attributes.
 
 Bleach can also linkify text safely, applying filters that Django's ``urlize``

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -47,16 +47,16 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
     :arg str text: the text to clean
 
-    :arg list tags: whitelist of allowed tags; defaults to
+    :arg list tags: allowed list of tags; defaults to
         ``bleach.ALLOWED_TAGS``
 
-    :arg dict attributes: whitelist of allowed attributes; defaults to
-        ``bleach.ALLOWED_ATTRIBUTES``
+    :arg dict attributes: allowed attributes; can be a callable, list or dict;
+        defaults to ``bleach.ALLOWED_ATTRIBUTES``
 
-    :arg list styles: whitelist of allowed css; defaults to
+    :arg list styles: allowed list of css styles; defaults to
         ``bleach.ALLOWED_STYLES``
 
-    :arg list protocols: whitelist of allowed protocols for links; defaults
+    :arg list protocols: allowed list of protocols for links; defaults
         to ``bleach.ALLOWED_PROTOCOLS``
 
     :arg bool strip: whether or not to strip disallowed elements
@@ -77,7 +77,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
     return cleaner.clean(text)
 
 
-def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False, parse_email=False):
+def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_tags=None, parse_email=False):
     """Convert URL-like strings in an HTML fragment to links
 
     This function converts strings that look like URLs, domain names and email
@@ -106,7 +106,9 @@ def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False, parse_email=False
 
     :arg list callbacks: list of callbacks to run when adjusting tag attributes
 
-    :arg bool skip_pre: whether or not to skip linkifying text in a ``pre`` tag
+    :arg list skip_tags: list of tags that you don't want to linkify the
+        contents of; for example, you could set this to ``['pre']`` to skip
+        linkifying contents of ``pre`` tags
 
     :arg bool parse_email: whether or not to linkify email addresses
 
@@ -115,7 +117,7 @@ def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False, parse_email=False
     """
     linker = Linker(
         callbacks=callbacks,
-        skip_pre=skip_pre,
+        skip_tags=skip_tags,
         parse_email=parse_email
     )
     return linker.linkify(text)

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -63,16 +63,16 @@ class Cleaner(object):
                  strip_comments=True, filters=None):
         """Initializes a Cleaner
 
-        :arg tags: whitelist of allowed tags; defaults to
+        :arg list tags: allowed list of tags; defaults to
             ``bleach.ALLOWED_TAGS``
 
-        :arg attributes: whitelist of allowed attributes; defaults to
-            ``bleach.ALLOWED_ATTRIBUTES``
+        :arg dict attributes: allowed attributes; can be a callable, list or dict;
+            defaults to ``bleach.ALLOWED_ATTRIBUTES``
 
-        :arg styles: whitelist of allowed css; defaults to
+        :arg list styles: allowed list of css styles; defaults to
             ``bleach.ALLOWED_STYLES``
 
-        :arg protocols: whitelist of allowed protocols for links; defaults
+        :arg list protocols: allowed list of protocols for links; defaults
             to ``bleach.ALLOWED_PROTOCOLS``
 
         :arg strip: whether or not to strip disallowed elements
@@ -196,7 +196,27 @@ class BleachSanitizerFilter(sanitizer.Filter):
     def __init__(self, source, attributes=ALLOWED_ATTRIBUTES,
                  strip_disallowed_elements=False, strip_html_comments=True,
                  **kwargs):
+        """Creates a BleachSanitizerFilter instance
 
+        :arg Treewalker source: stream
+
+        :arg list tags: allowed list of tags; defaults to
+            ``bleach.ALLOWED_TAGS``
+
+        :arg dict attributes: allowed attributes; can be a callable, list or dict;
+            defaults to ``bleach.ALLOWED_ATTRIBUTES``
+
+        :arg list styles: allowed list of css styles; defaults to
+            ``bleach.ALLOWED_STYLES``
+
+        :arg list protocols: allowed list of protocols for links; defaults
+            to ``bleach.ALLOWED_PROTOCOLS``
+
+        :arg strip_disallowed_elements: whether or not to strip disallowed elements
+
+        :arg strip_html_comments: whether or not to strip HTML comments
+
+        """
         self.attr_filter = attribute_filter_factory(attributes)
 
         self.strip_disallowed_elements = strip_disallowed_elements

--- a/docs/goals.rst
+++ b/docs/goals.rst
@@ -13,15 +13,15 @@ Goals
 =====
 
 
-Always take a whitelist-based approach
---------------------------------------
+Always take a allowed-list-based approach
+-----------------------------------------
 
-Bleach should always take a whitelist-based approach to allowing any kind of
-content or markup. Blacklisting is error-prone and not future proof.
+Bleach should always take a allowed-list-based approach to markup filtering.
+Specifying disallowed lists is error-prone and not future proof.
 
 For example, you should have to opt-in to allowing the ``onclick`` attribute,
-not blacklist all the other ``on*`` attributes. Future versions of HTML may add
-new event handlers, like ``ontouch``, that old blacklists would not prevent.
+not opt-out of all the other ``on*`` attributes. Future versions of HTML may add
+new event handlers, like ``ontouch``, that old disallow would not prevent.
 
 
 Main goal is to sanitize input of malicious content
@@ -39,8 +39,8 @@ Examples might include:
 
 These examples, and others, are traditionally prone to security issues like XSS
 or other script injection, or annoying issues like unclosed tags and invalid
-markup. Bleach will take a proactive, whitelist-only approach to allowing HTML
-content, and will use the HTML5 parsing algorithm to handle invalid markup.
+markup. Bleach will take a proactive, allowed-list-only approach to allowing
+HTML content, and will use the HTML5 parsing algorithm to handle invalid markup.
 
 See the :ref:`chapter on clean() <clean-chapter>` for more info.
 
@@ -52,7 +52,7 @@ The secondary goal of Bleach is to provide a mechanism for finding or altering
 links (``<a>`` tags with ``href`` attributes, or things that look like URLs or
 email addresses) in text.
 
-While Bleach itself will always operate on a whitelist-based security model,
+While Bleach itself will always operate on a allowed-list-based security model,
 the :ref:`linkify() method <linkify-chapter>` is flexible enough to allow the
 creation, alteration, and removal of links based on an extremely wide range of
 use cases.
@@ -69,8 +69,8 @@ Sanitize complete HTML documents
 --------------------------------
 
 Once you're creating whole documents, you have to allow so many tags that a
-blacklist approach (e.g. forbidding ``<script>`` or ``<object>``) may be more
-appropriate.
+disallow-list approach (e.g. forbidding ``<script>`` or ``<object>``) may be
+more appropriate.
 
 
 Remove all HTML or transforming content for some non-web-page purpose

--- a/docs/linkify.rst
+++ b/docs/linkify.rst
@@ -248,15 +248,13 @@ For example, this removes any ``mailto:`` links:
    u'mail janet!'
 
 
-Skipping links in pre blocks (``skip_pre``)
-===========================================
+Skipping links in specified tag blocks (``skip_tags``)
+======================================================
 
 ``<pre>`` tags are often special, literal sections. If you don't want to create
-any new links within a ``<pre>`` section, pass ``skip_pre=True``.
+any new links within a ``<pre>`` section, pass ``skip_tags=['pre']``.
 
-.. note::
-   Though new links will not be created, existing links created with ``<a>``
-   tags will still be passed through all the callbacks.
+This works for ``code``, ``div`` and any other blocks you want to skip over.
 
 
 Linkifying email addresses (``parse_email``)
@@ -281,7 +279,7 @@ instance.
 
    >>> from bleach.linkifier import Linker
 
-   >>> linker = Linker(skip_pre=True)
+   >>> linker = Linker(skip_tags=['pre'])
    >>> linker.linkify('a b c http://example.com d e f')
    u'a b c <a href="http://example.com" rel="nofollow">http://example.com</a> d e f'
 
@@ -328,7 +326,7 @@ And passing parameters to ``LinkifyFilter``:
 
    >>> cleaner = Cleaner(
    ...     tags=['pre'],
-   ...     filters=[partial(LinkifyFilter, skip_pre=True)]
+   ...     filters=[partial(LinkifyFilter, skip_tags=['pre'])]
    ... )
    ...
    >>> cleaner.clean('<pre>http://example.com</pre>')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if 'test' in sys.argv:
 tests_require = [
     'pytest>=3.0.0',
 ]
-    
+
 install_requires = [
     'six',
     # >= 8 9s because of breaking API change
@@ -42,7 +42,7 @@ def get_version():
 setup(
     name='bleach',
     version=get_version(),
-    description='An easy whitelist-based HTML-sanitizing tool.',
+    description='An easy safelist-based HTML-sanitizing tool.',
     long_description=get_long_desc(),
     maintainer='Will Kahn-Greene',
     url='http://github.com/mozilla/bleach',

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -357,24 +357,24 @@ def test_unsafe_url():
     )
 
 
-def test_skip_pre():
-    """Skip linkification in <pre> tags."""
+def test_skip_tags():
+    """Skip linkification in skip tags"""
     simple = 'http://xx.com <pre>http://xx.com</pre>'
     linked = ('<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
               '<pre>http://xx.com</pre>')
     all_linked = ('<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
                   '<pre><a href="http://xx.com" rel="nofollow">http://xx.com'
                   '</a></pre>')
-    assert linkify(simple, skip_pre=True) == linked
+    assert linkify(simple, skip_tags=['pre']) == linked
     assert linkify(simple) == all_linked
 
     already_linked = '<pre><a href="http://xx.com">xx</a></pre>'
     nofollowed = '<pre><a href="http://xx.com" rel="nofollow">xx</a></pre>'
     assert linkify(already_linked) == nofollowed
-    assert linkify(already_linked, skip_pre=True) == nofollowed
+    assert linkify(already_linked, skip_tags=['pre']) == nofollowed
 
     assert (
-        linkify('<pre><code>http://example.com</code></pre>http://example.com', skip_pre=True) ==
+        linkify('<pre><code>http://example.com</code></pre>http://example.com', skip_tags=['pre']) ==
         (
             '<pre><code>http://example.com</code></pre>'
             '<a href="http://example.com" rel="nofollow">http://example.com</a>'


### PR DESCRIPTION
This changes skip_pre to a more general skip_tags that lets you skip linkifying
in a specified list of tags--not just pre.

This fixes #194.