### PR TITLE
Add comparison of Bleach vs html5lib to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,19 @@ The simplest way to use Bleach is:
     u'an <a href="http://example.com" rel="nofollow">http://example.com</a> url
 
 
+Bleach vs html5lib
+==================
+
+Bleach is built upon html5lib_, and html5lib has `a built-in sanitizer <https://github.com/html5lib/html5lib-python/blob/1.0b10/html5lib/serializer.py#L148>`_, so why use Bleach?
+
+* Bleach's API is simpler.
+* Bleach's sanitizer allows a map to be provided for ``ALLOWED_ATTRIBUTES``, giving you a lot more control over sanitizing attributes: you can sanitize attributes for specific tags, you can sanitize based on value, etc.
+* Bleach's sanitizer always alphabetizes attributes, but uses an alphabetizer that works with namespaces — the html5lib one is broken in that regard.
+* Bleach's sanitizer always quotes attribute values because that's the safe thing to do. The html5lib one makes that configurable. In this case, Bleach doesn't make something configurable that isn't safe.
+* Bleach's sanitizer has a very restricted set of ``ALLOWED_PROTOCOLS`` by default. html5lib has a much more expansive one that Bleach's authors claim is less safe.
+* ``html5lib.filters.sanitizer.Filter``'s ``sanitize_css`` is broken and doesn't work.
+
+
 .. _html5lib: https://github.com/html5lib/html5lib-python
 .. _GitHub: https://github.com/mozilla/bleach
 .. _ReadTheDocs: https://bleach.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -89,19 +89,6 @@ The simplest way to use Bleach is:
     u'an <a href="http://example.com" rel="nofollow">http://example.com</a> url
 
 
-Bleach vs html5lib
-==================
-
-Bleach is built upon html5lib_, and html5lib has `a built-in sanitizer <https://github.com/html5lib/html5lib-python/blob/1.0b10/html5lib/serializer.py#L148>`_, so why use Bleach?
-
-* Bleach's API is simpler.
-* Bleach's sanitizer allows a map to be provided for ``ALLOWED_ATTRIBUTES``, giving you a lot more control over sanitizing attributes: you can sanitize attributes for specific tags, you can sanitize based on value, etc.
-* Bleach's sanitizer always alphabetizes attributes, but uses an alphabetizer that works with namespaces — the html5lib one is broken in that regard.
-* Bleach's sanitizer always quotes attribute values because that's the safe thing to do. The html5lib one makes that configurable. In this case, Bleach doesn't make something configurable that isn't safe.
-* Bleach's sanitizer has a very restricted set of ``ALLOWED_PROTOCOLS`` by default. html5lib has a much more expansive one that Bleach's authors claim is less safe.
-* ``html5lib.filters.sanitizer.Filter``'s ``sanitize_css`` is broken and doesn't work.
-
-
 .. _html5lib: https://github.com/html5lib/html5lib-python
 .. _GitHub: https://github.com/mozilla/bleach
 .. _ReadTheDocs: https://bleach.readthedocs.io/

--- a/docs/goals.rst
+++ b/docs/goals.rst
@@ -104,3 +104,16 @@ There are a number of interesting CSS properties that can do dangerous things,
 like Opera's ``-o-link``. Painful as it is, if you want your users to be able to
 change nearly anything in a ``style`` attribute, you should have to opt into
 this.
+
+
+Bleach vs html5lib
+==================
+
+Bleach is built upon html5lib_, and html5lib has `a built-in sanitizer <https://github.com/html5lib/html5lib-python/blob/1.0b10/html5lib/serializer.py#L148>`_, so why use Bleach?
+
+* Bleach's API is simpler.
+* Bleach's sanitizer allows a map to be provided for ``ALLOWED_ATTRIBUTES``, giving you a lot more control over sanitizing attributes: you can sanitize attributes for specific tags, you can sanitize based on value, etc.
+* Bleach's sanitizer always alphabetizes attributes, but uses an alphabetizer that works with namespaces — the html5lib one is broken in that regard.
+* Bleach's sanitizer always quotes attribute values because that's the safe thing to do. The html5lib one makes that configurable. In this case, Bleach doesn't make something configurable that isn't safe.
+* Bleach's sanitizer has a very restricted set of ``ALLOWED_PROTOCOLS`` by default. html5lib has a much more expansive one that Bleach's authors claim is less safe.
+* ``html5lib.filters.sanitizer.Filter``'s ``sanitize_css`` is broken and doesn't work.


### PR DESCRIPTION
Used notes provided by @willkg on #277 to add a short description of why Bleach may be preferable to html5lib’s built-in sanitizer.

Let me know if you think this should live somewhere else.