### PR TITLE
Clarify the dangers of using bleach.clean() output in html attributes

### DIFF
--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -11,9 +11,35 @@ Given a fragment of HTML, Bleach will parse it according to the HTML5 parsing
 algorithm and sanitize any disallowed tags or attributes. This algorithm also
 takes care of things like unclosed and (some) misnested tags.
 
-.. note::
-   You may pass in a ``string`` or a ``unicode`` object, but Bleach will
-   always return ``unicode``.
+You may pass in a ``string`` or a ``unicode`` object, but Bleach will always
+return ``unicode``.
+
+.. Note::
+
+   :py:func:`bleach.clean` is for sanitizing HTML **fragments** and not entire
+   HTML documents.
+
+
+.. Warning::
+
+   :py:func:`bleach.clean` is for sanitising HTML fragments to use in an HTML
+   context--not for HTML attributes.
+
+   For example, this is safe::
+
+     <p>
+       {{ bleach.clean(user_bio) }}
+     </p>
+
+
+   This is **not safe**::
+
+     <body data-bio="{{ bleach.clean(user_bio} }}">
+
+
+   If you need to use the output of ``bleach.clean()`` in an HTML attribute, you
+   need to pass it through your template library's escape function. For example,
+   Jinja2's ``escape`` or ``django.utils.html.escape`` or something like that.
 
 
 .. autofunction:: bleach.clean

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -5,7 +5,7 @@ Bleach development
 Install for development
 =======================
 
-To install Bleach to make changes to it::
+To install Bleach to make changes to it:
 
 1. Clone the repo from GitHub::
 

--- a/docs/goals.rst
+++ b/docs/goals.rst
@@ -68,9 +68,32 @@ non-goal use cases include:
 Sanitize complete HTML documents
 --------------------------------
 
-Once you're creating whole documents, you have to allow so many tags that a
-disallow-list approach (e.g. forbidding ``<script>`` or ``<object>``) may be
-more appropriate.
+Bleach's ``clean`` is not for sanitizing entire HTML documents. Once you're
+creating whole documents, you have to allow so many tags that a disallow-list
+approach (e.g. forbidding ``<script>`` or ``<object>``) may be more appropriate.
+
+
+Sanitize for use in HTML attributes
+-----------------------------------
+
+Bleach's ``clean`` is used for sanitizing content to be used in an HTML
+context--not for HTML attributes.
+
+For example, this is safe::
+
+    <p>
+      {{ bleach.clean(user_bio) }}
+    </p>
+
+
+This is **not safe**::
+
+    <body data-bio="{{ bleach.clean(user_bio} }}">
+
+
+If you need to use the output of ``bleach.clean()`` in an HTML attribute, you
+need to pass it through your template library's escape function. For example,
+Jinja2's ``escape`` or ``django.utils.html.escape`` or something like that.
 
 
 Remove all HTML or transforming content for some non-web-page purpose


### PR DESCRIPTION
This clarifies the dangers usage of `bleach.clean` output in HTML attributes with examples and some other commentary.