### PR TITLE
Linkify and clean should accept only six.string_types

### DIFF
--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import re
+import six
 
 import html5lib
 from html5lib.filters.base import Filter
@@ -135,21 +136,25 @@ class Linker(object):
         :returns: linkified text as unicode
 
         """
-        text = force_unicode(text)
+        if isinstance(text, six.string_types):
 
-        if not text:
-            return u''
+            text = force_unicode(text)
 
-        dom = self.parser.parseFragment(text)
-        filtered = LinkifyFilter(
-            source=self.walker(dom),
-            callbacks=self.callbacks,
-            skip_tags=self.skip_tags,
-            parse_email=self.parse_email,
-            url_re=self.url_re,
-            email_re=self.email_re,
-        )
-        return self.serializer.render(filtered)
+            if not text:
+                return u''
+
+            dom = self.parser.parseFragment(text)
+            filtered = LinkifyFilter(
+                source=self.walker(dom),
+                callbacks=self.callbacks,
+                skip_tags=self.skip_tags,
+                parse_email=self.parse_email,
+                url_re=self.url_re,
+                email_re=self.email_re,
+            )
+            return self.serializer.render(filtered)
+
+        raise TypeError('argument must of text type')
 
 
 class LinkifyFilter(Filter):

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import re
+import six
 from xml.sax.saxutils import unescape
 
 import html5lib
@@ -125,32 +126,36 @@ class Cleaner(object):
         :returns: sanitized text as unicode
 
         """
-        if not text:
-            return u''
+        if isinstance(text, six.string_types):
 
-        text = force_unicode(text)
+            if not text:
+                return u''
 
-        dom = self.parser.parseFragment(text)
-        filtered = BleachSanitizerFilter(
-            source=self.walker(dom),
+            text = force_unicode(text)
 
-            # Bleach-sanitizer-specific things
-            attributes=self.attributes,
-            strip_disallowed_elements=self.strip,
-            strip_html_comments=self.strip_comments,
+            dom = self.parser.parseFragment(text)
+            filtered = BleachSanitizerFilter(
+                source=self.walker(dom),
 
-            # html5lib-sanitizer things
-            allowed_elements=self.tags,
-            allowed_css_properties=self.styles,
-            allowed_protocols=self.protocols,
-            allowed_svg_properties=[],
-        )
+                # Bleach-sanitizer-specific things
+                attributes=self.attributes,
+                strip_disallowed_elements=self.strip,
+                strip_html_comments=self.strip_comments,
 
-        # Apply any filters after the BleachSanitizerFilter
-        for filter_class in self.filters:
-            filtered = filter_class(source=filtered)
+                # html5lib-sanitizer things
+                allowed_elements=self.tags,
+                allowed_css_properties=self.styles,
+                allowed_protocols=self.protocols,
+                allowed_svg_properties=[],
+            )
 
-        return self.serializer.render(filtered)
+            # Apply any filters after the BleachSanitizerFilter
+            for filter_class in self.filters:
+                filtered = filter_class(source=filtered)
+
+            return self.serializer.render(filtered)
+
+        raise TypeError('argument must of text type')
 
 
 def attribute_filter_factory(attributes):

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -639,3 +639,16 @@ class TestLinkify:
 
         assert linkify(linked) == link_good
         assert linkify(link_good) == link_good
+
+    def test_only_text_is_linkified(self):
+        some_text = 'text'
+        some_type = int
+        no_type = None
+
+        assert linkify(some_text) == some_text
+
+        with pytest.raises(TypeError):
+            linkify(some_type)
+
+        with pytest.raises(TypeError):
+            linkify(no_type)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -184,3 +184,17 @@ def test_regression_manually():
     expected = """&lt;img src="jav\rascript:alert(&amp;lt;WBR&amp;gt;'XSS');"&gt;"""
 
     assert clean(s) == expected
+
+
+def test_only_text_is_cleaned():
+    some_text = 'text'
+    some_type = int
+    no_type = None
+
+    assert clean(some_text) == some_text
+
+    with pytest.raises(TypeError):
+        clean(some_type)
+
+    with pytest.raises(TypeError):
+        clean(no_type)


### PR DESCRIPTION
Linkify and clean should accept only six.string_types and otherwise now they raise TypeError.

This PR solves the issue: #292 