### PR TITLE
Fix links in mails with hyphen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 docs/_build/
 .cache/
 .eggs/
+.*env*/

--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -344,7 +344,17 @@ class LinkifyFilter(Filter):
 
     def handle_links(self, src_iter):
         """Handle links in character tokens"""
+        in_a = False  # happens, if parse_email=True and if a mail was found
         for token in src_iter:
+            if in_a:
+                if token['type'] == 'EndTag' and token['name'] == 'a':
+                    in_a = False
+                yield token
+                continue
+            elif token['type'] == 'StartTag' and token['name'] == 'a':
+                in_a = True
+                yield token
+                continue
             if token['type'] == 'Characters':
                 text = token['data']
                 new_tokens = []

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import re
 import sys
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -588,6 +588,14 @@ def test_hang():
     )
 
 
+def test_hyphen_in_mail():
+    """Test hyphens `-` in mails. Issue #300."""
+    assert (
+        linkify('ex@am-ple.com', parse_email=True) ==
+        '<a href="mailto:ex@am-ple.com">ex@am-ple.com</a>'
+    )
+
+
 def test_url_re_arg():
     """Verifies that a specified url_re is used"""
     fred_re = re.compile(r"""(fred\.com)""")


### PR DESCRIPTION
Do not create a http link inside a mailto link

Partly fixes #300:

```py
>>> linkify('foo@exa-mple.com', parse_email=True)
'<a href="mailto:foo@exa-mple.com">foo@exa<a href="http://-mple.com" rel="nofollow">-mple.com</a></a>'
'<a href="mailto:foo@exa-mple.com">foo@exa-mple.com</a>'
```

but it does not fix this issue:

```py
>>> linkify('foo@bar-baz.com')
'foo@bar<a href="http://-baz.com" rel="nofollow">-baz.com</a>'
```