### PR TITLE
Fix character entities in HTML attributes

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -131,6 +131,20 @@ def test_bare_entities(text, expected):
         'http://example.com?active=true&amp;current=true'
     ),
 
+    # Test entities in HTML attributes
+    (
+        '<a href="?art&amp;copy">foo</a>',
+        '<a href="?art&amp;copy">foo</a>'
+    ),
+    (
+        '<a href="?this=&gt;that">foo</a>',
+        '<a href="?this=&gt;that">foo</a>'
+    ),
+    (
+        '<a href="http://example.com?active=true&current=true">foo</a>',
+        '<a href="http://example.com?active=true&amp;current=true">foo</a>'
+    ),
+
     # Test numeric entities
     ('&#39;', '&#39;'),
     ('&#34;', '&#34;'),


### PR DESCRIPTION
This is option 2 in 

https://github.com/mozilla/bleach/issues/294#issuecomment-331233053

I thought this would be more involved, but it wasn't. Go figure.

This is squirrely, but what's going on is that the tokenizer no longer consumes
entities so when the serializer goes to convert all & to &amp;, it's not a good
thing to do.

This wraps the serializer and looks for HTML attribute values, undoes the
categorical "all & shall be &amp;!" and then redoes it taking care only to
escape bare &.

Fixes #294.