### PR TITLE
Insert the provided type in error message when it's a wrong one

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -194,7 +194,9 @@ class Cleaner(object):
 
         """
         if not isinstance(text, six.string_types):
-            raise TypeError('argument must be of text type')
+            message = 'argument cannot be of {name} type, must be of text type'.format(
+                name=text.__class__.__name__)
+            raise TypeError(message)
 
         if not text:
             return u''

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -194,7 +194,7 @@ class Cleaner(object):
 
         """
         if not isinstance(text, six.string_types):
-            message = 'argument cannot be of {name} type, must be of text type'.format(
+            message = "argument cannot be of '{name}' type, must be of text type".format(
                 name=text.__class__.__name__)
             raise TypeError(message)
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -427,14 +427,14 @@ def test_clean_idempotent():
 
 def test_only_text_is_cleaned():
     some_text = 'text'
-    some_type = 42
+    some_type = int
     no_type = None
 
     assert bleach.clean(some_text) == some_text
 
     with pytest.raises(TypeError) as e:
         bleach.clean(some_type)
-    assert "int" in str(e)
+    assert "argument cannot be of 'type' type" in str(e)
 
     with pytest.raises(TypeError) as e:
         bleach.clean(no_type)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -427,16 +427,18 @@ def test_clean_idempotent():
 
 def test_only_text_is_cleaned():
     some_text = 'text'
-    some_type = int
+    some_type = 42
     no_type = None
 
     assert bleach.clean(some_text) == some_text
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as e:
         bleach.clean(some_type)
+    assert "int" in str(e)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as e:
         bleach.clean(no_type)
+    assert "NoneType" in str(e)
 
 
 class TestCleaner:


### PR DESCRIPTION
so, for example, the error message will be 'argument cannot be of int type, must be of text type'.

It can help for debugging.