### PR TITLE
Handle ambiguous ampersands correctly

### DIFF
--- a/tests/data/6.test
+++ b/tests/data/6.test
@@ -1,0 +1,3 @@
+<a href="javas&#x09;cript:alert(1)">hi</a>
+--
+<a>hi</a>


### PR DESCRIPTION
This fixes the ambiguous ampersand case in character entity handling in
attribute values.

Fixes #359