### PR TITLE
Convert entities in CSS values before sanitizing

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -702,7 +702,10 @@ class BleachSanitizerFilter(sanitizer.Filter):
 
     def sanitize_css(self, style):
         """Sanitizes css in style tags"""
-        # Drop any url values
+        # Convert entities in the style so that it can be parsed as CSS
+        style = convert_entities(style)
+
+        # Drop any url values before we do anything else
         style = re.compile('url\s*\(\s*[^\s)]+?\s*\)\s*').sub(' ', style)
 
         # The gauntlet of sanitization

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -127,11 +127,10 @@ def test_valid_css():
         '<p style="background: #00D;">foo</p>'
     ),
 
-    # Verify urls with character entities--this isn't valid, so the entire
-    # property is dropped
+    # Verify urls with character entities
     (
         '<p style="background: url&#x09;(\'topbanner.png\') #00D;">foo</p>',
-        '<p style="">foo</p>'
+        '<p style="background: #00D;">foo</p>'
     ),
 
 ])
@@ -201,3 +200,20 @@ def test_style_hang():
     )
 
     assert clean(html, styles=styles) == expected
+
+
+@pytest.mark.parametrize('data, styles, expected', [
+    (
+        '<p style="font-family: Droid Sans, serif; white-space: pre-wrap;">text</p>',
+        ['font-family', 'white-space'],
+        '<p style="font-family: Droid Sans, serif; white-space: pre-wrap;">text</p>'
+    ),
+    (
+        '<p style="font-family: &quot;Droid Sans&quot;, serif; white-space: pre-wrap;">text</p>',
+        ['font-family', 'white-space'],
+        '<p style=\'font-family: "Droid Sans", serif; white-space: pre-wrap;\'>text</p>'
+    ),
+])
+def test_css_parsing_with_entities(data, styles, expected):
+    """The sanitizer should be ok with character entities"""
+    assert clean(data, tags=['p'], attributes={'p': ['style']}, styles=styles) == expected


### PR DESCRIPTION
The CSS is in an HTML attribute value, so we need to convert character
entities in it which makes it proper CSS before we can sanitize it.

Fixes #363