### PR TITLE
Drop support for html5lib<1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,9 @@ python:
 - "3.5"
 - "3.6"
 - "pypy"
-env:
-- HTML5LIB=0.99999999   # 8
-- HTML5LIB=0.999999999  # 9
 install:
-  # html5lib 0.99999999 (8 9s) requires at least setuptools 18.5
   - pip install -U pip setuptools>=18.5
   - pip install -r requirements-dev.txt
-  # stomp on html5lib install with the specified one
-  - pip install html5lib==$HTML5LIB
 script:
 - py.test
 - flake8 bleach/

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import warnings
 from pkg_resources import parse_version
 
 from bleach.linkifier import (
@@ -16,20 +15,6 @@ from bleach.sanitizer import (
     ALLOWED_TAGS,
     Cleaner,
 )
-
-
-import html5lib
-try:
-    _html5lib_version = html5lib.__version__.split('.')
-    if len(_html5lib_version) < 2:
-        _html5lib_version = _html5lib_version + ['0']
-except Exception:
-    _h5ml5lib_version = ['unknown', 'unknown']
-
-
-# Bleach 3.0.0 won't support html5lib-python < 1.0.0.
-if _html5lib_version < ['1', '0'] or 'b' in _html5lib_version[1]:
-    warnings.warn('Support for html5lib-python < 1.0.0 is deprecated.', DeprecationWarning)
 
 
 # yyyymmdd

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ tests_require = [
 
 install_requires = [
     'six',
-    # >= 8 9s because of breaking API change
-    # the 'pre' suffix is needed for supporting '1.0b*' versions
-    'html5lib>=0.99999999pre,!=1.0b1,!=1.0b2,!=1.0b3,!=1.0b4,!=1.0b5,!=1.0b6,!=1.0b7,!=1.0b8',
+    'html5lib>=1',
 ]
 
 

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -410,7 +410,7 @@ def test_end_of_clause():
     )
 
 
-@pytest.mark.xfail(reason='html5lib >= 0.99999999: changed API')
+@pytest.mark.xfail(reason='html5lib >= 1.0: changed API')
 def test_sarcasm():
     """Jokes should crash.<sarcasm/>"""
     assert linkify('Yeah right <sarcasm/>') == 'Yeah right &lt;sarcasm/&gt;'

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,7 @@
 
 [tox]
 envlist =
-    py{27,34,35,36}-html5lib{99999999,999999999,10b9,10b10,101}
-    pypy-html5lib99999999
+    py{27,34,35,36,py}
     py{27,34,35,36}-build-no-lang
     docs
     lint
@@ -19,11 +18,6 @@ basepython =
     py36: python3.6
 deps =
     -rrequirements-dev.txt
-    html5lib99999999: html5lib==0.99999999
-    html5lib999999999: html5lib==0.999999999
-    html5lib10b9: html5lib==1.0b9
-    html5lib10b10: html5lib==1.0b10
-    html5lib101: html5lib==1.0.1
 commands =
     py.test {posargs:-v}
     python setup.py build


### PR DESCRIPTION
This is a duplicate of https://github.com/mozilla/bleach/pull/343 (except for CHANGES).

I had hastily deleted my fork after another PR was merged, and forgot #343 was still open, and now that one is unmergeable.

So here's a recreated PR, sorry for the noise!

No rush to merge this, see https://github.com/mozilla/bleach/pull/343#issuecomment-352434866.