### PR TITLE
Add Python 3.7, htmllib 1.0b10 and 1.0.1 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ python:
 - "3.4"
 - "3.5"
 - "3.6"
+- "3.7"
 - "pypy"
 env:
 - HTML5LIB=0.99999999   # 8
 - HTML5LIB=0.999999999  # 9
+- HTML5LIB=1.0b10
+- HTML5LIB=1.0.1
 install:
   # html5lib 0.99999999 (8 9s) requires at least setuptools 18.5
   - pip install -U pip setuptools>=18.5

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist =
     py{27,34,35,36}-html5lib{99999999,999999999,10b9,10b10,101}
     pypy-html5lib99999999
-    py{27,34,35,36}-build-no-lang
+    py{27,34,35,36,37}-build-no-lang
     docs
     lint
 
@@ -17,6 +17,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py36: python3.7
 deps =
     -rrequirements-dev.txt
     html5lib99999999: html5lib==0.99999999
@@ -56,15 +57,22 @@ setenv =
 commands =
     python setup.py build
 
+[testenv:py37-build-no-lang]
+basepython = python3.7
+setenv =
+    LANG=
+commands =
+    python setup.py build
+
 [testenv:lint]
-basepython = python3.6
+basepython = python3.7
 deps =
     -rrequirements-dev.txt
 commands =
     flake8 bleach/
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.7
 changedir = docs
 deps =
     -rrequirements-dev.txt


### PR DESCRIPTION
Fixes #377, plus add the most recent htmlib versions. The new tox targets worked locally (thanks pyenv!)

Based on ``setup.py``, it looks like htmllib 0.99999999 (8) should be dropped from the tests.