### PR TITLE
Drop easy_install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,10 +58,6 @@ Bleach is available on PyPI_, so you can install it with ``pip``::
 
     $ pip install bleach
 
-Or with ``easy_install``::
-
-    $ easy_install bleach
-
 
 Upgrading Bleach
 ================


### PR DESCRIPTION
This isn't earth-shattering or anything. I haven't tested `easy_install` installation ever, so I don't even know if it works anymore.

Fixes #373.