### PR TITLE
fixes #392: linkify fix

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -38,8 +38,9 @@ ENTITIES = entities
 ENTITIES_TRIE = Trie(ENTITIES)
 
 #: Token type constants--these never change
-START_TAG_TYPE = tokenTypes['StartTag']
-END_TAG_TYPE = tokenTypes['EndTag']
+TAG_TOKEN_TYPES = set([
+    tokenTypes['StartTag'], tokenTypes['EndTag'], tokenTypes['EmptyTag']
+])
 CHARACTERS_TYPE = tokenTypes['Characters']
 
 
@@ -158,10 +159,10 @@ class BleachHTMLTokenizer(HTMLTokenizer):
             self.tokenQueue.append({"type": CHARACTERS_TYPE, "data": '&'})
 
     def tagOpenState(self):
-        # This state marks a < that is either a StartTag, EndTag, or ParseError.
-        # In all cases, we want to drop any stream history we've collected
-        # so far and we do that by calling start_tag() on the input stream
-        # wrapper.
+        # This state marks a < that is either a StartTag, EndTag, EmptyTag,
+        # or ParseError. In all cases, we want to drop any stream history
+        # we've collected so far and we do that by calling start_tag() on
+        # the input stream wrapper.
         self.stream.start_tag()
         return super(BleachHTMLTokenizer, self).tagOpenState()
 
@@ -169,11 +170,11 @@ class BleachHTMLTokenizer(HTMLTokenizer):
         token = self.currentToken
 
         if ((self.parser.tags is not None and
-             token['type'] in (START_TAG_TYPE, END_TAG_TYPE) and
+             token['type'] in TAG_TOKEN_TYPES and
              token['name'].lower() not in self.parser.tags)):
-            # If this is a start/end tag for a tag that's not in our allowed
-            # list, then it gets stripped or escaped. In both of these cases
-            # it gets converted to a Characters token.
+            # If this is a start/end/empty tag for a tag that's not in our
+            # allowed list, then it gets stripped or escaped. In both of these
+            # cases it gets converted to a Characters token.
             if self.parser.strip:
                 # If we're stripping the token, we just throw in an empty
                 # string token.

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -15,11 +15,10 @@ from bleach._vendor.html5lib import (
     HTMLParser,
     getTreeWalker,
 )
+from bleach._vendor.html5lib import constants
 from bleach._vendor.html5lib.constants import (
-    entities,
     namespaces,
     prefixes,
-    tokenTypes,
 )
 from bleach._vendor.html5lib.constants import _ReparseException as ReparseException
 from bleach._vendor.html5lib.filters.base import Filter
@@ -32,16 +31,18 @@ from bleach._vendor.html5lib._trie import Trie
 
 
 #: Map of entity name to expanded entity
-ENTITIES = entities
+ENTITIES = constants.entities
 
 #: Trie of html entity string -> character representation
 ENTITIES_TRIE = Trie(ENTITIES)
 
 #: Token type constants--these never change
 TAG_TOKEN_TYPES = set([
-    tokenTypes['StartTag'], tokenTypes['EndTag'], tokenTypes['EmptyTag']
+    constants.tokenTypes['StartTag'],
+    constants.tokenTypes['EndTag'],
+    constants.tokenTypes['EmptyTag']
 ])
-CHARACTERS_TYPE = tokenTypes['Characters']
+CHARACTERS_TYPE = constants.tokenTypes['Characters']
 
 
 class InputStreamWithMemory(object):
@@ -140,7 +141,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
 
             # If the token is a ParseError, we hold on to it so we can get the
             # next token and potentially fix it.
-            if token['type'] == tokenTypes['ParseError']:
+            if token['type'] == constants.tokenTypes['ParseError']:
                 last_error_token = token
                 continue
 

--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -110,9 +110,16 @@ class Linker(object):
         self.url_re = url_re
         self.email_re = email_re
 
-        self.parser = html5lib_shim.HTMLParser(namespaceHTMLElements=False)
+        # Create a parser/tokenizer that allows all HTML tags and escapes
+        # anything not in that list.
+        self.parser = html5lib_shim.BleachHTMLParser(
+            tags=html5lib_shim.HTML_TAGS,
+            strip=False,
+            consume_entities=True,
+            namespaceHTMLElements=False,
+        )
         self.walker = html5lib_shim.getTreeWalker('etree')
-        self.serializer = html5lib_shim.HTMLSerializer(
+        self.serializer = html5lib_shim.BleachHTMLSerializer(
             quote_attr_values='always',
             omit_optional_tags=False,
 

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -126,6 +126,7 @@ class Cleaner(object):
         self.parser = html5lib_shim.BleachHTMLParser(
             tags=self.tags,
             strip=self.strip,
+            consume_entities=False,
             namespaceHTMLElements=False
         )
         self.walker = html5lib_shim.getTreeWalker('etree')

--- a/docs/linkify.rst
+++ b/docs/linkify.rst
@@ -5,12 +5,20 @@
 Linkifying text fragments
 =========================
 
-:py:func:`bleach.linkify` searches text for links, URLs, and email addresses and
-lets you control how and when those links are rendered.
+Bleach comes with several tools for searching text for links, URLs, and email
+addresses and letting you specify how those links are rendered in HTML.
 
-It works by building a document tree, so it's guaranteed never to do weird
-things to URLs in attribute values, can modify the value of attributes on
-``<a>`` tags and can even do things like skip ``<pre>`` sections.
+For example, you could pass in text and have all URL things converted into
+HTML links.
+
+It works by parsing the text as HTML and building a document tree. In this
+way, it's guaranteed never to do weird things to URLs in attribute values,
+can modify the value of attributes on ``<a>`` tags and can even do things
+like skip ``<pre>`` sections.
+
+If you plan to sanitize/clean the text and linkify it, you should do that
+in a single pass using :ref:`LinkifyFilter <linkify-LinkifyFilter>`. This
+is faster and it'll use the list of allowed tags from clean.
 
 .. note::
 
@@ -308,6 +316,7 @@ instance.
 
 .. versionadded:: 2.0
 
+.. _linkify-LinkifyFilter:
 
 Using ``bleach.linkifier.LinkifyFilter``
 ========================================

--- a/tests/test_html5lib_shim.py
+++ b/tests/test_html5lib_shim.py
@@ -62,6 +62,7 @@ def test_serializer(data, expected):
     parser = html5lib_shim.BleachHTMLParser(
         tags=None,
         strip=True,
+        consume_entities=False,
         namespaceHTMLElements=False
     )
     walker = html5lib_shim.getTreeWalker('etree')

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -407,7 +407,6 @@ def test_end_of_clause():
     )
 
 
-@pytest.mark.xfail(reason='html5lib >= 0.99999999: changed API')
 def test_sarcasm():
     """Jokes should crash.<sarcasm/>"""
     assert linkify('Yeah right <sarcasm/>') == 'Yeah right &lt;sarcasm/&gt;'
@@ -581,7 +580,7 @@ def test_hang():
     """This string would hang linkify. Issue #200"""
     assert (
         linkify("an@email.com<mailto:an@email.com>", parse_email=True) ==
-        '<a href="mailto:an@email.com">an@email.com</a><mailto:an@email.com></mailto:an@email.com>'
+        '<a href="mailto:an@email.com">an@email.com</a>&lt;mailto:<a href="mailto:an@email.com">an@email.com</a>&gt;'  # noqa
     )
 
 


### PR DESCRIPTION
This tweaks the code for the `BleachHTMLParser` and `BleachHTMLTokenizer` to work with the needs of the linkifier. This fixes the case where the linkifier was "fixing" non-HTML tags like `</sarcasm>`.

Fixes #392.