### PR TITLE
Add abbr to HTML_TAGS

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -56,6 +56,8 @@ HTML_TAGS = [
         list(constants.mathmlTextIntegrationPointElements)
     )
 ]
+# Add tags that aren't in html5lib.constants
+HTML_TAGS.extend(['abbr'])
 
 
 class InputStreamWithMemory(object):

--- a/scripts/vendor_verify.sh
+++ b/scripts/vendor_verify.sh
@@ -21,3 +21,7 @@ diff -r \
     --exclude="pip_install_vendor.sh" \
     --exclude="__pycache__" \
     bleach/_vendor/ "${DEST}"
+
+if [ $? == 0 ]; then
+    rm -rf "${DEST}"
+fi

--- a/scripts/vendor_verify.sh
+++ b/scripts/vendor_verify.sh
@@ -12,8 +12,14 @@ fi
 
 mkdir "${DEST}"
 
+# Get versions of pip and python
+pip --version
+
+# Install vendored dependencies into temp directory
 pip install --no-binary all --no-compile --no-deps -r bleach/_vendor/vendor.txt --target "${DEST}"
 
+# Diff contents of temp directory and bleach/_vendor/ excluding vnedoring
+# infrastructure
 diff -r \
     --exclude="__init__.py" \
     --exclude="README.rst" \
@@ -22,6 +28,7 @@ diff -r \
     --exclude="__pycache__" \
     bleach/_vendor/ "${DEST}"
 
+# If everything is cool, then delete the temp directory
 if [ $? == 0 ]; then
     rm -rf "${DEST}"
 fi


### PR DESCRIPTION
This fixes the issue where linkify will escape `<abbr>`.

Fixes #400