### PR TITLE
fix 377 - add python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,15 @@ install:
 
 matrix:
   include:
-    - python: 2.7
+    - python: "2.7"
       env: MODE=lint
-    - python: 2.7
+    - python: "2.7"
       env: MODE=vendorverify
-    - python: 3.4
+    - python: "3.4"
       env: MODE=lint
+    - python: "3.7"
+      sudo: required
+      dist: xenial
 
 script:
   - ./scripts/run_tests.sh $MODE

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,27 @@
 Bleach changes
 ==============
 
+Version 3.0.1 (in development)
+------------------------------
+
+**Security fixes**
+
+None
+
+**Backwards incompatible changes**
+
+None
+
+**Features**
+
+* Support Python 3.7. (#377)
+
+**Bug fixes**
+
+* Fix `'list' object has no attribute 'lower'` in clean. (#398)
+* Fix `abbr` getting escaped in linkify. (#400)
+ 
+
 Version 3.0.0 (October 3rd, 2018)
 ---------------------------------
 

--- a/scripts/vendor_verify.sh
+++ b/scripts/vendor_verify.sh
@@ -20,15 +20,27 @@ pip install --no-binary all --no-compile --no-deps -r bleach/_vendor/vendor.txt 
 
 # Diff contents of temp directory and bleach/_vendor/ excluding vnedoring
 # infrastructure
+echo "diffing directory trees..."
 diff -r \
     --exclude="__init__.py" \
     --exclude="README.rst" \
     --exclude="vendor.txt" \
     --exclude="pip_install_vendor.sh" \
     --exclude="__pycache__" \
+    --exclude="RECORD" \
     bleach/_vendor/ "${DEST}"
 
+# Go through all RECORD files and compare sorted versions; RECORD files are
+# unsorted and occasionally diff poorly
+for fn in $(cd bleach/_vendor/; find . -name RECORD); do
+    echo "diffing bleach/_vendor/${fn} and ${DEST}/${fn} ..."
+    diff <(sort bleach/_vendor/${fn}) <(sort ${DEST}/${fn})
+done
+
 # If everything is cool, then delete the temp directory
-if [ $? == 0 ]; then
+LASTEXIT=$?
+if [ ${LASTEXIT} -eq 0 ]; then
     rm -rf "${DEST}"
 fi
+
+exit ${LASTEXIT}

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@
 
 [tox]
 envlist =
-    py{27,34,35,36}
+    py{27,34,35,36,37}
     pypy
-    py{27,34,35,36}-build-no-lang
+    py{27,34,35,36,37}-build-no-lang
     docs
     lint
     vendorverify
@@ -20,6 +20,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps =
     -rrequirements-dev.txt
 commands =
@@ -49,6 +50,13 @@ commands =
 
 [testenv:py36-build-no-lang]
 basepython = python3.6
+setenv =
+    LANG=
+commands =
+    python setup.py build
+
+[testenv:py37-build-no-lang]
+basepython = python3.7
 setenv =
     LANG=
 commands =


### PR DESCRIPTION
This fixes `vendor_verify.sh` script accounting for `RECORD` being unsorted and occasionally failing the diff.

This also adds testing Bleach in Python 3.7 to tox and Travis.