### PR TITLE
initial attempt at stripping content of script and style tags

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -29,7 +29,7 @@ __all__ = ['clean', 'linkify']
 
 def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
           styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
-          strip_comments=True):
+          strip_comments=True, tags_strip_content=None, ):
     """Clean an HTML fragment of malicious content and return it
 
     This function is a security-focused function whose sole purpose is to
@@ -70,6 +70,8 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
     :arg bool strip_comments: whether or not to strip HTML comments
 
+    :arg list tags_strip_content: list of tags to strip contents of.
+
     :returns: cleaned text as unicode
 
     """
@@ -80,6 +82,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
         protocols=protocols,
         strip=strip,
         strip_comments=strip_comments,
+        tags_strip_content=tags_strip_content
     )
     return cleaner.clean(text)
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -845,3 +845,53 @@ class TestCleaner:
             cleaner.clean(dirty) ==
             'this is cute! <img rel="moo" src="moo">'
         )
+
+
+def test_strip_tags():
+    # this is flat
+    _input_1 = 'foo.<div>bar.<script type="text/javascript">alert(1);</script>bar2.<script>alert(2);</script>bar3.<style>.body{}</style>bar4.<style tyle="text/css">.body{}</style>bar5.</div>biz'
+
+    assert (clean(_input_1, tags=['div', ], tags_strip_content=['script', 'style']) ==
+            'foo.<div>bar.bar2.bar3.bar4.bar5.</div>biz'
+            )
+
+    assert (clean(_input_1, tags=['div', ], tags_strip_content=['script', 'style'], strip=True) ==
+            'foo.<div>bar.bar2.bar3.bar4.bar5.</div>biz'
+            )
+
+    # `style` is escaped, because it is not stripped or allowed
+    assert (clean(_input_1, tags=['div', ], tags_strip_content=['SCRIPT', ], ) ==
+            'foo.<div>bar.bar2.bar3.&lt;style&gt;.body{}&lt;/style&gt;bar4.&lt;style tyle="text/css"&gt;.body{}&lt;/style&gt;bar5.</div>biz'
+            )
+
+    # the `stle` content becomes plaintext
+    assert (clean(_input_1, tags=['div', ], tags_strip_content=['SCRIPT', ], strip=True) ==
+            'foo.<div>bar.bar2.bar3..body{}bar4..body{}bar5.</div>biz'
+            )
+
+    assert (clean(_input_1, tags=['div', ], tags_strip_content=['StYLe', ]) ==
+            'foo.<div>bar.&lt;script type="text/javascript"&gt;alert(1);&lt;/script&gt;bar2.&lt;script&gt;alert(2);&lt;/script&gt;bar3.bar4.bar5.</div>biz'
+            )
+
+    # the `script` content becomes plaintext
+    assert (clean(_input_1, tags=['div', ], tags_strip_content=['StYLe', ], strip=True) ==
+            'foo.<div>bar.alert(1);bar2.alert(2);bar3.bar4.bar5.</div>biz'
+            )
+
+    # nested, nested+malformed
+    _input_2 = 'foo.<div>bar.<script type="text/javascript">alert(1);<div>alpha.<style><div>beta.</style></div></script>bang.</div>biz'
+    _input_2_b = 'foo.<div>bar.<script type="text/javascript">alert(1);<div>alpha.<style><div>beta.</style></div>bang.</div>biz'
+
+    assert (clean(_input_2, tags=['div', ], tags_strip_content=['SCRIPT', ], ) ==
+            'foo.<div>bar.bang.</div>biz'
+            )
+    assert (clean(_input_2_b, tags=['div', ], tags_strip_content=['SCRIPT', ], ) ==
+            'foo.<div>bar.</div>'
+            )
+
+    assert (clean(_input_2, tags=['div', ], tags_strip_content=['SCRIPT', ], strip=True) ==
+            'foo.<div>bar.bang.</div>biz'
+            )
+    assert (clean(_input_2_b, tags=['div', ], tags_strip_content=['SCRIPT', ], strip=True) ==
+            'foo.<div>bar.</div>'
+            )


### PR DESCRIPTION
this is an attempt at addressing #234 (removing the contents of script and style tags)

a new option is added to several methods: `tags_strip_content`. this is a list of tags which should have their content stripped.

the stripping is achieved in two phases:

1. The tokenizer will ignore these tags.
2. The serializer maintains state of being in a tag marked for stripping

I had tried to do an alternate implementation in which:

* the tokenizer would escape/strip the tag as in the current implementation
* the tokenizer adds a payload to the token noting that it should be stripped

unfortunately that approach is incompatible with multiple parts of the tag parsing. there may be a way to convert the tags to something else (perhaps `<unsafe>` then strip out the unsafe tags on render.

this could be refactored into a new 'prettify' function as previously suggested, but it seems cleaner as a kwarg
