### PR TITLE
filtering tags and their contents 

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -29,7 +29,7 @@ __all__ = ['clean', 'linkify']
 
 def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
           styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
-          strip_comments=True):
+          strip_comments=True, filters=None):
     """Clean an HTML fragment of malicious content and return it
 
     This function is a security-focused function whose sole purpose is to
@@ -70,6 +70,15 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
 
     :arg bool strip_comments: whether or not to strip HTML comments
 
+    :arg list filters: list of html5lib Filter classes to pass streamed content through
+
+        .. seealso:: http://html5lib.readthedocs.io/en/latest/movingparts.html#filters
+
+        .. Warning::
+
+           Using filters changes the output of ``bleach.Cleaner.clean``.
+           Make sure the way the filters change the output are secure.
+
     :returns: cleaned text as unicode
 
     """
@@ -80,6 +89,7 @@ def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
         protocols=protocols,
         strip=strip,
         strip_comments=strip_comments,
+        filters=filters,
     )
     return cleaner.clean(text)
 

--- a/bleach/extras.py
+++ b/bleach/extras.py
@@ -16,10 +16,10 @@ class TagTreeFilter(Filter):
     def __init__(self, source, tags_strip_content=TAG_TREE_TAGS):
         """
         Creates a TagTreeFilter instance.
-        
+
         This instance will strip the tag and the content tree of tags appearing
         in ``tags_strip_content``.
-        
+
         :arg Treewalker source: stream
         :arg list tags_strip_content: a list of tags which should be stripped
                                       along with their content/children.
@@ -44,10 +44,11 @@ class TagTreeFilter(Filter):
             yield token
 
 
-def clean_strip_content(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
+def clean_strip_content(
+    text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
     styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
     strip_comments=True, tags_strip_content=TAG_TREE_TAGS, filters=None,
-    ):
+):
     # whitelist the tags we want to strip, so they can be filtered out
     tags = [t.lower() for t in tags]
     tags_strip_content = [t.lower() for t in tags_strip_content]

--- a/bleach/extras.py
+++ b/bleach/extras.py
@@ -1,0 +1,77 @@
+from bleach.html5lib_shim import Filter
+from bleach.sanitizer import (
+    ALLOWED_ATTRIBUTES,
+    ALLOWED_PROTOCOLS,
+    ALLOWED_STYLES,
+    ALLOWED_TAGS,
+    Cleaner,
+)
+
+
+TAG_TREE_TAGS = ('script', 'style', )
+
+
+class TagTreeFilter(Filter):
+
+    def __init__(self, source, tags_strip_content=TAG_TREE_TAGS):
+        """
+        Creates a TagTreeFilter instance.
+        
+        This instance will strip the tag and the content tree of tags appearing
+        in ``tags_strip_content``.
+        
+        :arg Treewalker source: stream
+        :arg list tags_strip_content: a list of tags which should be stripped
+                                      along with their content/children.
+        """
+        if not tags_strip_content:
+            raise ValueError('must submit `tags_strip_content`')
+        self.tags_strip_content = [t.lower() for t in tags_strip_content]
+        self._in_strip_content = 0
+        return super(TagTreeFilter, self).__init__(source)
+
+    def __iter__(self):
+        for token in Filter.__iter__(self):
+            _name = token.get('name', '').lower()
+            if _name in self.tags_strip_content:
+                if token.get('type') == 'StartTag':
+                    self._in_strip_content += 1
+                elif token.get('type') == 'EndTag':
+                    self._in_strip_content -= 1
+                continue
+            if self._in_strip_content:
+                continue
+            yield token
+
+
+def clean_strip_content(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
+    styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
+    strip_comments=True, tags_strip_content=TAG_TREE_TAGS, filters=None,
+    ):
+    # whitelist the tags we want to strip, so they can be filtered out
+    tags = [t.lower() for t in tags]
+    tags_strip_content = [t.lower() for t in tags_strip_content]
+    for t in tags_strip_content:
+        if t not in tags:
+            tags.append(t)
+    # ensure we apply the `TagTreeFilter` defined above
+    if filters is None:
+        filters = [TagTreeFilter, ]
+    elif TagTreeFilter not in filters:
+        filters.append(TagTreeFilter)
+    cleaner = Cleaner(
+        tags=tags,
+        attributes=attributes,
+        styles=styles,
+        protocols=protocols,
+        strip=strip,
+        strip_comments=strip_comments,
+        filters=filters,
+    )
+    return cleaner.clean(text)
+
+
+__all__ = ('TAG_TREE_TAGS',
+           'TagTreeFilter',
+           'clean_strip_content',
+           )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -845,3 +845,69 @@ class TestCleaner:
             cleaner.clean(dirty) ==
             'this is cute! <img rel="moo" src="moo">'
         )
+
+
+def test_interface_options():
+    from bleach.extras import clean_strip_content, TagTreeFilter
+
+    _input = 'foo.<div>bar.<script type="text/javascript">alert(1);<div>alpha.<style><div>beta.</style></div></script>bang.</div>biz'
+    assert (clean_strip_content(_input, tags=['div', ], ) ==
+            'foo.<div>bar.bang.</div>biz'
+            )
+    assert (clean_strip_content(_input, tags=['div', 'script', 'style'], ) ==
+            'foo.<div>bar.bang.</div>biz'
+            )
+    assert (clean_strip_content(_input, tags=['div', 'script', 'style'], filters=[TagTreeFilter, ]) ==
+            'foo.<div>bar.bang.</div>biz'
+            )
+
+def test_strip_tags():
+    from bleach.extras import clean_strip_content
+
+    # this is flat
+    _input_1 = 'foo.<div>bar.<script type="text/javascript">alert(1);</script>bar2.<script>alert(2);</script>bar3.<style>.body{}</style>bar4.<style tyle="text/css">.body{}</style>bar5.</div>biz'
+
+    assert (clean_strip_content(_input_1, tags=['div', ], tags_strip_content=['script', 'style']) ==
+            'foo.<div>bar.bar2.bar3.bar4.bar5.</div>biz'
+            )
+
+    assert (clean_strip_content(_input_1, tags=['div', ], tags_strip_content=['script', 'style'], strip=True) ==
+            'foo.<div>bar.bar2.bar3.bar4.bar5.</div>biz'
+            )
+
+    # `style` is escaped, because it is not stripped or allowed
+    assert (clean_strip_content(_input_1, tags=['div', ], tags_strip_content=['SCRIPT', ], ) ==
+            'foo.<div>bar.bar2.bar3.&lt;style&gt;.body{}&lt;/style&gt;bar4.&lt;style tyle="text/css"&gt;.body{}&lt;/style&gt;bar5.</div>biz'
+            )
+
+    # the `stle` content becomes plaintext
+    assert (clean_strip_content(_input_1, tags=['div', ], tags_strip_content=['SCRIPT', ], strip=True) ==
+            'foo.<div>bar.bar2.bar3..body{}bar4..body{}bar5.</div>biz'
+            )
+
+    assert (clean_strip_content(_input_1, tags=['div', ], tags_strip_content=['StYLe', ]) ==
+            'foo.<div>bar.&lt;script type="text/javascript"&gt;alert(1);&lt;/script&gt;bar2.&lt;script&gt;alert(2);&lt;/script&gt;bar3.bar4.bar5.</div>biz'
+            )
+
+    # the `script` content becomes plaintext
+    assert (clean_strip_content(_input_1, tags=['div', ], tags_strip_content=['StYLe', ], strip=True) ==
+            'foo.<div>bar.alert(1);bar2.alert(2);bar3.bar4.bar5.</div>biz'
+            )
+
+    # nested, nested+malformed
+    _input_2 = 'foo.<div>bar.<script type="text/javascript">alert(1);<div>alpha.<style><div>beta.</style></div></script>bang.</div>biz'
+    _input_2_b = 'foo.<div>bar.<script type="text/javascript">alert(1);<div>alpha.<style><div>beta.</style></div>bang.</div>biz'
+
+    assert (clean_strip_content(_input_2, tags=['div', ], tags_strip_content=['SCRIPT', ], ) ==
+            'foo.<div>bar.bang.</div>biz'
+            )
+    assert (clean_strip_content(_input_2_b, tags=['div', ], tags_strip_content=['SCRIPT', ], ) ==
+            'foo.<div>bar.</div>'
+            )
+
+    assert (clean_strip_content(_input_2, tags=['div', ], tags_strip_content=['SCRIPT', ], strip=True) ==
+            'foo.<div>bar.bang.</div>biz'
+            )
+    assert (clean_strip_content(_input_2_b, tags=['div', ], tags_strip_content=['SCRIPT', ], strip=True) ==
+            'foo.<div>bar.</div>'
+            )


### PR DESCRIPTION
this could be broken up into two PRs/concepts.

1. the main `bleach.clean` function is extended with a filters argument, which simply proxies the value to `Cleaner.__init__`

2. an `extras.py` was added to support a `TagTreeFilter`, which is a filter capable of removing an entire tag tree.  as a reference, utility and test-requirement a function named `clean_strip_content` was also included to invoke this.  This function addresses #234

For the concern of security/safety, this filter deletes the entire tree of a matching tag - including any tags that may appear within it.