### PR TITLE
Fix six dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'six',
+    'six>=1.9.0',
     # html5lib requirements
     'webencodings',
 ]


### PR DESCRIPTION
After tracing through a build failure in our of my projects, I found out that (1) we weren't clearing our virtualenv's in our builds and (2) your vendored version of [html5lib requires `six>=1.9`](https://github.com/html5lib/html5lib-python/blob/1.0.1/requirements.txt#L1).  It's buried in the [vendored METADATA](https://github.com/mozilla/bleach/blob/master/bleach/_vendor/html5lib-1.0.1.dist-info/METADATA#L25) file as well.

For the sake of posterity and googler's everywhere, here's the traceback that I got with an older version of six installed.

```
Traceback (most recent call last):
  File "./setup.py", line 47, in <module>
    'Programming Language :: Python :: 2.7',
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/setuptools/__init__.py", line 140, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/setuptools/command/sdist.py", line 52, in run
    self.run_command(cmd_name)
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 970, in run_command
    cmd_obj = self.get_command_obj(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 845, in get_command_obj
    klass = self.get_command_class(command)
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/setuptools/dist.py", line 635, in get_command_class
    self.cmdclass[command] = cmdclass = ep.load()
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2332, in load
    return self.resolve()
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2338, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/readme_renderer/integration/distutils.py", line 25, in <module>
    from ..rst import render
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/readme_renderer/rst.py", line 22, in <module>
    from .clean import clean
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/readme_renderer/clean.py", line 18, in <module>
    import bleach
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/bleach/__init__.py", line 7, in <module>
    from bleach.linkifier import (
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/bleach/linkifier.py", line 6, in <module>
    from bleach import html5lib_shim
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/bleach/html5lib_shim.py", line 14, in <module>
    from bleach._vendor.html5lib import (
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/bleach/_vendor/html5lib/__init__.py", line 25, in <module>
    from .html5parser import HTMLParser, parse, parseFragment
  File "/var/lib/jenkins/shiningpanda/jobs/1f336430/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/bleach/_vendor/html5lib/html5parser.py", line 2, in <module>
    from six import with_metaclass, viewkeys
ImportError: cannot import name viewkeys
```