### PR TITLE
drop invalid attribute names

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,28 @@
 Bleach changes
 ==============
 
+Version 3.0.3 (In development)
+------------------------------
+
+**Security fixes**
+
+None
+
+**Backwards incompatible changes**
+
+None
+
+**Features**
+
+* Add ``recognized_tags`` argument to the linkify ``Linker`` class. This
+  fixes issues when linkifying on its own and having some tags get escaped.
+  It defaults to a list of HTML5 tags. Thank you, Chad Birch! (#409)
+
+**Bug fixes**
+
+* Add ``six>=1.9`` to requirements. Thank you, Dave Shawley (#416)
+
+
 Version 3.0.2 (October 11th, 2018)
 ----------------------------------
 

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -20,7 +20,7 @@ from bleach.sanitizer import (
 # yyyymmdd
 __releasedate__ = ''
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = '3.0.3'
+__version__ = '3.0.3.dev0'
 VERSION = parse_version(__version__)
 
 

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -18,9 +18,9 @@ from bleach.sanitizer import (
 
 
 # yyyymmdd
-__releasedate__ = '20181011'
+__releasedate__ = ''
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = '3.0.2'
+__version__ = '3.0.3'
 VERSION = parse_version(__version__)
 
 

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -69,6 +69,17 @@ def test_mangle_text():
     )
 
 
+def test_invalid_attribute_names():
+    """Test that "invalid-character-in-attribute-name" errors in tokenizing
+    result in attributes with invalid names get dropped.
+
+    """
+    assert (
+        linkify('<a href="http://example.com/"">') ==
+        '<a href="http://example.com/" rel="nofollow"></a>'
+    )
+
+
 @pytest.mark.parametrize('data,parse_email,expected', [
     (
         'a james@example.com mailto',
@@ -119,7 +130,7 @@ def test_email_link(data, parse_email, expected):
     assert linkify(data, parse_email=parse_email) == expected
 
 
-@pytest.mark.parametrize('data,expected', [
+@pytest.mark.parametrize('data, expected', [
     (
         '"james"@example.com',
         '''<a href='mailto:"james"@example.com'>"james"@example.com</a>'''


### PR DESCRIPTION
This fixes the case where the `HTMLTokenizer` will be tokenizing and hit a character that kicks up an `invalid-character-in-attribute-name` error. Previously, the tokenizer would create the attribute anyhow and keep on chugging along.

For Bleach's purposes, it's better to drop that invalid attribute altogether. This fixes the `BleachHTMLTokenizer` to do that.

Fixes #419.