### PR TITLE
Shim for wrapped stream, InputStreamWithMemory, charEncoding:

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -188,6 +188,10 @@ class InputStreamWithMemory(object):
             self._buffer.append(c)
         return c
 
+    @property
+    def charEncoding(self, *args, **kwargs):
+        return self._inner_stream.charEncoding(*args, **kwargs)
+
     def charsUntil(self, characters, opposite=False):
         chars = self._inner_stream.charsUntil(characters, opposite=opposite)
         self._buffer.extend(list(chars))


### PR DESCRIPTION
AttributeError: 'InputStreamWithMemory' object has no attribute 'charEncoding'
(16 additional frame(s) were not displayed)
...
  File "bleach/_vendor/html5lib/html5parser.py", line 241, in mainLoop
    new_token = phase.processStartTag(new_token)
  File "bleach/_vendor/html5lib/html5parser.py", line 472, in processStartTag
    return self.startTagHandler[token["name"]](token)
  File "bleach/_vendor/html5lib/html5parser.py", line 1067, in startTagProcessInHead
    return self.parser.phases["inHead"].processStartTag(token)
  File "bleach/_vendor/html5lib/html5parser.py", line 472, in processStartTag
    return self.startTagHandler[token["name"]](token)
  File "bleach/_vendor/html5lib/html5parser.py", line 745, in startTagMeta
    if self.parser.tokenizer.stream.charEncoding[1] == "tentative":

Signed-off-by: allen-munsch <enderplux@protonmail.com>