### PR TITLE
Convert &amp; to & as a Characters token

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -395,7 +395,18 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
             if part.startswith('&'):
                 entity = html5lib_shim.match_entity(part)
                 if entity is not None:
-                    new_tokens.append({'type': 'Entity', 'name': entity})
+                    if entity == 'amp':
+                        # LinkifyFilter can't match urls across token boundaries
+                        # which is problematic with &amp; since that shows up in
+                        # querystrings all the time. This special-cases &amp;
+                        # and converts it to a & and sticks it in as a
+                        # Characters token. It'll get merged with surrounding
+                        # tokens in the BleachSanitizerfilter.__iter__ and
+                        # escaped in the serializer.
+                        new_tokens.append({'type': 'Characters', 'data': '&'})
+                    else:
+                        new_tokens.append({'type': 'Entity', 'name': entity})
+
                     # Length of the entity plus 2--one for & at the beginning
                     # and and one for ; at the end
                     remainder = part[len(entity) + 2:]

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -695,6 +695,10 @@ class TestLinkify:
         '<a href="http://example.com?b=1&amp;c=2">http://example.com?b=1&amp;c=2</a>'
     ),
     (
+        'http://example.com?b=1&amp;c=2',
+        '<a href="http://example.com?b=1&amp;c=2">http://example.com?b=1&amp;c=2</a>'
+    ),
+    (
         'link: https://example.com/watch#anchor',
         'link: <a href="https://example.com/watch#anchor">https://example.com/watch#anchor</a>'
     )


### PR DESCRIPTION
This fixes a problem in `LinkifyFilter` when using it with the `Cleaner` where
the `Cleaner` sets up the tokenizer to not consume entities. So character
entities end up in their own `Entity` tokens and `Linkifyfilter` can't match
links that cross token boundaries. If there's a `&amp;`, then `LinkifyFilter`
won't match across that.

This fixes that by converting `&amp;` to `&` in the sanitizer when it's pulling out
entities and putting them in separate `Entity` tokens. The `&` `Characters` tokens
will get merged by `BleachSanitizerFilter.__iter__` and `&` will get converted
back to `&amp;` in the serialier.

Fixes #422