### PR TITLE
Remove u string prefix in files with unicode_literals

### DIFF
--- a/bleach/callbacks.py
+++ b/bleach/callbacks.py
@@ -3,31 +3,31 @@ from __future__ import unicode_literals
 
 
 def nofollow(attrs, new=False):
-    href_key = (None, u'href')
+    href_key = (None, 'href')
 
     if href_key not in attrs:
         return attrs
 
-    if attrs[href_key].startswith(u'mailto:'):
+    if attrs[href_key].startswith('mailto:'):
         return attrs
 
-    rel_key = (None, u'rel')
-    rel_values = [val for val in attrs.get(rel_key, u'').split(u' ') if val]
-    if u'nofollow' not in [rel_val.lower() for rel_val in rel_values]:
-        rel_values.append(u'nofollow')
-    attrs[rel_key] = u' '.join(rel_values)
+    rel_key = (None, 'rel')
+    rel_values = [val for val in attrs.get(rel_key, '').split(' ') if val]
+    if 'nofollow' not in [rel_val.lower() for rel_val in rel_values]:
+        rel_values.append('nofollow')
+    attrs[rel_key] = ' '.join(rel_values)
 
     return attrs
 
 
 def target_blank(attrs, new=False):
-    href_key = (None, u'href')
+    href_key = (None, 'href')
 
     if href_key not in attrs:
         return attrs
 
-    if attrs[href_key].startswith(u'mailto:'):
+    if attrs[href_key].startswith('mailto:'):
         return attrs
 
-    attrs[(None, u'target')] = u'_blank'
+    attrs[(None, 'target')] = '_blank'
     return attrs

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -447,7 +447,7 @@ def convert_entities(text):
 
         new_text.append(part)
 
-    return u''.join(new_text)
+    return ''.join(new_text)
 
 
 def match_entity(stream):

--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -149,7 +149,7 @@ class Linker(object):
         text = force_unicode(text)
 
         if not text:
-            return u''
+            return ''
 
         dom = self.parser.parseFragment(text)
         filtered = LinkifyFilter(
@@ -250,7 +250,7 @@ class LinkifyFilter(html5lib_shim.Filter):
             if token_type in ['Characters', 'SpaceCharacters']:
                 out.append(token['data'])
 
-        return u''.join(out)
+        return ''.join(out)
 
     def handle_email_addresses(self, src_iter):
         """Handle email addresses in character tokens"""
@@ -264,31 +264,31 @@ class LinkifyFilter(html5lib_shim.Filter):
                 for match in self.email_re.finditer(text):
                     if match.start() > end:
                         new_tokens.append(
-                            {u'type': u'Characters', u'data': text[end:match.start()]}
+                            {'type': 'Characters', 'data': text[end:match.start()]}
                         )
 
                     # Run attributes through the callbacks to see what we
                     # should do with this match
                     attrs = {
-                        (None, u'href'): u'mailto:%s' % match.group(0),
-                        u'_text': match.group(0)
+                        (None, 'href'): 'mailto:%s' % match.group(0),
+                        '_text': match.group(0)
                     }
                     attrs = self.apply_callbacks(attrs, True)
 
                     if attrs is None:
                         # Just add the text--but not as a link
                         new_tokens.append(
-                            {u'type': u'Characters', u'data': match.group(0)}
+                            {'type': 'Characters', 'data': match.group(0)}
                         )
 
                     else:
                         # Add an "a" tag for the new link
-                        _text = attrs.pop(u'_text', '')
+                        _text = attrs.pop('_text', '')
                         attrs = alphabetize_attributes(attrs)
                         new_tokens.extend([
-                            {u'type': u'StartTag', u'name': u'a', u'data': attrs},
-                            {u'type': u'Characters', u'data': force_unicode(_text)},
-                            {u'type': u'EndTag', u'name': 'a'}
+                            {'type': 'StartTag', 'name': 'a', 'data': attrs},
+                            {'type': 'Characters', 'data': force_unicode(_text)},
+                            {'type': 'EndTag', 'name': 'a'}
                         ])
                     end = match.end()
 
@@ -296,7 +296,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                     # Yield the adjusted set of tokens and then continue
                     # through the loop
                     if end < len(text):
-                        new_tokens.append({u'type': u'Characters', u'data': text[end:]})
+                        new_tokens.append({'type': 'Characters', 'data': text[end:]})
 
                     for new_token in new_tokens:
                         yield new_token
@@ -316,12 +316,12 @@ class LinkifyFilter(html5lib_shim.Filter):
         while fragment:
             # Try removing ( from the beginning and, if it's balanced, from the
             # end, too
-            if fragment.startswith(u'('):
-                prefix = prefix + u'('
+            if fragment.startswith('('):
+                prefix = prefix + '('
                 fragment = fragment[1:]
 
-                if fragment.endswith(u')'):
-                    suffix = u')' + suffix
+                if fragment.endswith(')'):
+                    suffix = ')' + suffix
                     fragment = fragment[:-1]
                 continue
 
@@ -331,21 +331,21 @@ class LinkifyFilter(html5lib_shim.Filter):
             #
             #     "i looked at the site (at http://example.com)"
 
-            if fragment.endswith(u')') and u'(' not in fragment:
+            if fragment.endswith(')') and '(' not in fragment:
                 fragment = fragment[:-1]
-                suffix = u')' + suffix
+                suffix = ')' + suffix
                 continue
 
             # Handle commas
-            if fragment.endswith(u','):
+            if fragment.endswith(','):
                 fragment = fragment[:-1]
-                suffix = u',' + suffix
+                suffix = ',' + suffix
                 continue
 
             # Handle periods
-            if fragment.endswith(u'.'):
+            if fragment.endswith('.'):
                 fragment = fragment[:-1]
-                suffix = u'.' + suffix
+                suffix = '.' + suffix
                 continue
 
             # Nothing matched, so we're done
@@ -374,7 +374,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                 for match in self.url_re.finditer(text):
                     if match.start() > end:
                         new_tokens.append(
-                            {u'type': u'Characters', u'data': text[end:match.start()]}
+                            {'type': 'Characters', 'data': text[end:match.start()]}
                         )
 
                     url = match.group(0)
@@ -388,39 +388,39 @@ class LinkifyFilter(html5lib_shim.Filter):
                     if PROTO_RE.search(url):
                         href = url
                     else:
-                        href = u'http://%s' % url
+                        href = 'http://%s' % url
 
                     attrs = {
-                        (None, u'href'): href,
-                        u'_text': url
+                        (None, 'href'): href,
+                        '_text': url
                     }
                     attrs = self.apply_callbacks(attrs, True)
 
                     if attrs is None:
                         # Just add the text
                         new_tokens.append(
-                            {u'type': u'Characters', u'data': prefix + url + suffix}
+                            {'type': 'Characters', 'data': prefix + url + suffix}
                         )
 
                     else:
                         # Add the "a" tag!
                         if prefix:
                             new_tokens.append(
-                                {u'type': u'Characters', u'data': prefix}
+                                {'type': 'Characters', 'data': prefix}
                             )
 
-                        _text = attrs.pop(u'_text', '')
+                        _text = attrs.pop('_text', '')
                         attrs = alphabetize_attributes(attrs)
 
                         new_tokens.extend([
-                            {u'type': u'StartTag', u'name': u'a', u'data': attrs},
-                            {u'type': u'Characters', u'data': force_unicode(_text)},
-                            {u'type': u'EndTag', u'name': 'a'},
+                            {'type': 'StartTag', 'name': 'a', 'data': attrs},
+                            {'type': 'Characters', 'data': force_unicode(_text)},
+                            {'type': 'EndTag', 'name': 'a'},
                         ])
 
                         if suffix:
                             new_tokens.append(
-                                {u'type': u'Characters', u'data': suffix}
+                                {'type': 'Characters', 'data': suffix}
                             )
 
                     end = match.end()
@@ -429,7 +429,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                     # Yield the adjusted set of tokens and then continue
                     # through the loop
                     if end < len(text):
-                        new_tokens.append({u'type': u'Characters', u'data': text[end:]})
+                        new_tokens.append({'type': 'Characters', 'data': text[end:]})
 
                     for new_token in new_tokens:
                         yield new_token

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -162,7 +162,7 @@ class Cleaner(object):
             raise TypeError(message)
 
         if not text:
-            return u''
+            return ''
 
         text = force_unicode(text)
 
@@ -528,7 +528,7 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
                             continue
 
                 # If it's a style attribute, sanitize it
-                if namespaced_name == (None, u'style'):
+                if namespaced_name == (None, 'style'):
                     val = self.sanitize_css(val)
 
                 # At this point, we want to keep the attribute, so add it in

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from bleach.callbacks import nofollow, target_blank
 
 
@@ -45,19 +47,19 @@ class TestTargetBlankCallback:
         assert target_blank(attrs) == attrs
 
     def test_mailto(self):
-        attrs = {(None, u'href'): u'mailto:joe@example.com'}
+        attrs = {(None, 'href'): 'mailto:joe@example.com'}
         assert target_blank(attrs) == attrs
 
     def test_add_target(self):
-        attrs = {(None, u'href'): u'http://example.com'}
+        attrs = {(None, 'href'): 'http://example.com'}
         assert (
             target_blank(attrs) ==
-            {(None, u'href'): u'http://example.com', (None, u'target'): u'_blank'}
+            {(None, 'href'): 'http://example.com', (None, 'target'): '_blank'}
         )
 
     def test_stomp_target(self):
-        attrs = {(None, u'href'): u'http://example.com', (None, u'target'): u'foo'}
+        attrs = {(None, 'href'): 'http://example.com', (None, 'target'): 'foo'}
         assert (
             target_blank(attrs) ==
-            {(None, u'href'): 'http://example.com', (None, u'target'): u'_blank'}
+            {(None, 'href'): 'http://example.com', (None, 'target'): '_blank'}
         )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import os
 
 import pytest
@@ -471,10 +473,10 @@ def test_attributes_callable():
     ATTRS = lambda tag, name, val: name == 'title'
     TAGS = ['a']
 
-    text = u'<a href="/foo" title="blah">example</a>'
+    text = '<a href="/foo" title="blah">example</a>'
     assert (
         clean(text, tags=TAGS, attributes=ATTRS) ==
-        u'<a title="blah">example</a>'
+        '<a title="blah">example</a>'
     )
 
 
@@ -501,8 +503,8 @@ def test_attributes_wildcard_callable():
     TAGS = ['a']
 
     assert (
-        clean(u'<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS) ==
-        u'<a title="blah">example</a>'
+        clean('<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS) ==
+        '<a title="blah">example</a>'
     )
 
 
@@ -519,12 +521,12 @@ def test_attributes_tag_callable():
     text = 'foo <img src="http://example.com" alt="blah"> baz'
     assert (
         clean(text, tags=TAGS, attributes=ATTRS) ==
-        u'foo <img> baz'
+        'foo <img> baz'
     )
     text = 'foo <img src="https://example.com" alt="blah"> baz'
     assert (
         clean(text, tags=TAGS, attributes=ATTRS) ==
-        u'foo <img src="https://example.com"> baz'
+        'foo <img src="https://example.com"> baz'
     )
 
 
@@ -536,8 +538,8 @@ def test_attributes_tag_list():
     TAGS = ['a']
 
     assert (
-        clean(u'<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS) ==
-        u'<a title="blah">example</a>'
+        clean('<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS) ==
+        '<a title="blah">example</a>'
     )
 
 
@@ -546,10 +548,10 @@ def test_attributes_list():
     ATTRS = ['title']
     TAGS = ['a']
 
-    text = u'<a href="/foo" title="blah">example</a>'
+    text = '<a href="/foo" title="blah">example</a>'
     assert (
         clean(text, tags=TAGS, attributes=ATTRS) ==
-        u'<a title="blah">example</a>'
+        '<a title="blah">example</a>'
     )
 
 

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from functools import partial
 
 import pytest
@@ -70,9 +72,9 @@ clean = partial(clean, tags=['p'], attributes=['style'])
     ),
     # Handle non-ascii characters in attributes
     (
-        u'<p style="font-family: \u30e1\u30a4\u30ea\u30aa; color: blue;">bar</p>',
-        [u'color'],
-        u'<p style="color: blue;">bar</p>'
+        '<p style="font-family: \u30e1\u30a4\u30ea\u30aa; color: blue;">bar</p>',
+        ['color'],
+        '<p style="color: blue;">bar</p>'
     ),
 ])
 def test_allowed_css(data, styles, expected):

--- a/tests/test_html5lib_shim.py
+++ b/tests/test_html5lib_shim.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import pytest
 
 from bleach import html5lib_shim
@@ -9,7 +11,7 @@ from bleach import html5lib_shim
     ('abc', 'abc'),
 
     # Handles character entities--both named and numeric
-    ('&nbsp;', u'\xa0'),
+    ('&nbsp;', '\xa0'),
     ('&#32;', ' '),
     ('&#x20;', ' '),
 

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import re
 
 import pytest
@@ -190,7 +192,7 @@ def test_set_attrs():
     """We can set random attributes on links."""
 
     def set_attr(attrs, new=False):
-        attrs[(None, u'rev')] = u'canonical'
+        attrs[(None, 'rev')] = 'canonical'
         return attrs
 
     assert (
@@ -562,14 +564,14 @@ def test_drop_link_tags():
 
 
 @pytest.mark.parametrize('text, expected', [
-    (u'&lt;br&gt;', u'&lt;br&gt;'),
+    ('&lt;br&gt;', '&lt;br&gt;'),
     (
-        u'&lt;br&gt; http://example.com',
-        u'&lt;br&gt; <a href="http://example.com" rel="nofollow">http://example.com</a>'
+        '&lt;br&gt; http://example.com',
+        '&lt;br&gt; <a href="http://example.com" rel="nofollow">http://example.com</a>'
     ),
     (
-        u'&lt;br&gt; <br> http://example.com',
-        u'&lt;br&gt; <br> <a href="http://example.com" rel="nofollow">http://example.com</a>'
+        '&lt;br&gt; <br> http://example.com',
+        '&lt;br&gt; <br> <a href="http://example.com" rel="nofollow">http://example.com</a>'
     )
 ])
 def test_naughty_unescaping(text, expected):


### PR DESCRIPTION
Using `from __future__ import unicode_literals` guarantees that all string literals will be Unicode strings by default. Using the u prefix is redundant. Cleans up the code towards a Python 3 style.