### PR TITLE
Simplify tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,14 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 # Note: If you update this, make sure to update .travis.yml, too.
 
 [tox]
 envlist =
-    py{27,34,35,36,37}
-    pypy
+    py{27,34,35,36,37,py}
     py{27,34,35,36,37}-build-no-lang
     docs
     lint
     vendorverify
 
 [testenv]
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
 deps =
     -rrequirements-dev.txt
 commands =
@@ -28,35 +16,30 @@ commands =
     python setup.py build
 
 [testenv:py27-build-no-lang]
-basepython = python2.7
 setenv =
     LANG=
 commands =
     python setup.py build
 
 [testenv:py34-build-no-lang]
-basepython = python3.4
 setenv =
     LANG=
 commands =
     python setup.py build
 
 [testenv:py35-build-no-lang]
-basepython = python3.5
 setenv =
     LANG=
 commands =
      python setup.py build
 
 [testenv:py36-build-no-lang]
-basepython = python3.6
 setenv =
     LANG=
 commands =
     python setup.py build
 
 [testenv:py37-build-no-lang]
-basepython = python3.7
 setenv =
     LANG=
 commands =


### PR DESCRIPTION
Remove boilerplate comment from the top of the file.

In envlist, move pypy to same line as rest of the default Python
environments.

Don't override basepython. The default uses the correct Python
executable:

https://tox.readthedocs.io/en/latest/config.html#conf-basepython

> If not specified, the virtual environments factors (e.g. name part)
> will be used to automatically set one. For example, py37 means
> python3.7, py3 means python3 and py means python.