### PR TITLE
Fix ResourceWarning emitted during tests

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -785,10 +785,11 @@ def get_ids_and_tests():
     # Sort numerically which makes it easier to iterate through them
     tests.sort(key=lambda x: int(os.path.basename(x).split('.', 1)[0]))
 
-    testcases = [
-        (os.path.basename(fn), open(fn, 'r').read())
-        for fn in tests
-    ]
+    testcases = []
+    for fn in tests:
+        with open(fn) as fp:
+            data = fp.read()
+        testcases.append((os.path.basename(fn), data))
 
     return testcases
 


### PR DESCRIPTION
Always close the open file by using a context manager. Previously
Appeared as:

    tests/test_clean.py:790
      tests/test_clean.py:790: ResourceWarning: unclosed file <_io.TextIOWrapper name='.../tests/data/1.test' mode='r' encoding='UTF-8'>
        for fn in tests