### PR TITLE
Update PyPI link to new location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,4 +114,4 @@ Participation Guidelines
 .. _html5lib: https://github.com/html5lib/html5lib-python
 .. _GitHub: https://github.com/mozilla/bleach
 .. _ReadTheDocs: https://bleach.readthedocs.io/
-.. _PyPI: http://pypi.python.org/pypi/bleach
+.. _PyPI: https://pypi.org/project/bleach/


### PR DESCRIPTION
Rebased #449 so we can land it by the 30th.

For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html