### PR TITLE
Issue 450: invalid character entities

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -488,7 +488,7 @@ def match_entity(stream):
         while stream and stream[0] not in end_characters:
             c = stream.pop(0)
             if c not in allowed:
-                break
+                return None
             possible_entity += c
 
         if possible_entity and stream and stream[0] == ';':
@@ -499,7 +499,7 @@ def match_entity(stream):
     while stream and stream[0] not in end_characters:
         c = stream.pop(0)
         if not ENTITIES_TRIE.has_keys_with_prefix(possible_entity):
-            break
+            return None
         possible_entity += c
 
     if possible_entity and stream and stream[0] == ';':

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -502,7 +502,7 @@ def match_entity(stream):
             return None
         possible_entity += c
 
-    if possible_entity and stream and stream[0] == ';':
+    if possible_entity and stream and stream[0] == ';' and possible_entity + ';' in ENTITIES_TRIE:
         return possible_entity
 
     return None

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -246,8 +246,8 @@ def test_bare_entities_get_escaped_correctly(text, expected):
         '<a href="http://example.com?active=true&amp;current=true">foo</a>'
     ),
 
-    # Ambiguous ampersands in text are not escaped
-    ('&xx;', '&xx;'),
+    # Invalid character entities in text are escaped
+    ('&xx;', '&amp;xx;'),
 
     # Test numeric entities
     ('&#39;', '&#39;'),
@@ -268,7 +268,7 @@ def test_bare_entities_get_escaped_correctly(text, expected):
     ('&#39;&#34;', '&#39;&#34;'),
 
     # Almost valid character entities (matching prefix of varying non matching lengths)
-    ('&ad;', '&ad;'),
+    ('&ad;', '&amp;ad;'),
     ('&adp;', '&amp;adp;'),
     ('&adpe;', '&amp;adpe;'),
 ])

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -259,12 +259,18 @@ def test_bare_entities_get_escaped_correctly(text, expected):
     # Test non-numeric entities
     ('&#', '&amp;#'),
     ('&#<', '&amp;#&lt;'),
+    ('&#1x;', '&amp;#1x;'),
 
     # html5lib tokenizer unescapes character entities, so these would become '
     # and " which makes it possible to break out of html attributes.
     #
     # Verify that clean() doesn't unescape entities.
     ('&#39;&#34;', '&#39;&#34;'),
+
+    # Almost valid character entities (matching prefix of varying non matching lengths)
+    ('&ad;', '&ad;'),
+    ('&adp;', '&amp;adp;'),
+    ('&adpe;', '&amp;adpe;'),
 ])
 def test_character_entities_handling(text, expected):
     assert clean(text) == expected


### PR DESCRIPTION
Possible fix for https://github.com/mozilla/bleach/issues/450.

This change fixes the case where there was precisely two characters between a valid character entity prefix and a semicolon, and the helper function returned the entity `ad` from `&adp;` (which later led to returning `&ad;;`.

In doing so, I also changed so that other invalid character entities (such as `&xx;`) were escaped, instead of keeping them around if the non-matchning parts were short. Not sure what you think about that?