### PR TITLE
Check parser.tags for None on "expected-closing-tag-but-got-char"

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -256,7 +256,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                     yield token
 
                 elif ((last_error_token['data'] == 'expected-closing-tag-but-got-char' and
-                     token['data'].lower().strip() not in self.parser.tags)):
+                     (self.parser.tags is None or token['data'].lower().strip() not in self.parser.tags))):
                     # We've got either a malformed tag or a pseudo-tag or
                     # something that html5lib wants to turn into a malformed
                     # comment which Bleach clean() will drop so we interfere

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -256,7 +256,8 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                     yield token
 
                 elif ((last_error_token['data'] == 'expected-closing-tag-but-got-char' and
-                     (self.parser.tags is None or token['data'].lower().strip() not in self.parser.tags))):
+                       self.parser.tags is not None and
+                       token['data'].lower().strip() not in self.parser.tags)):
                     # We've got either a malformed tag or a pseudo-tag or
                     # something that html5lib wants to turn into a malformed
                     # comment which Bleach clean() will drop so we interfere

--- a/tests/test_html5lib_shim.py
+++ b/tests/test_html5lib_shim.py
@@ -117,6 +117,11 @@ def test_serializer(data, expected):
         {},
         '<a href=\'http://example.com\'\'>',
         '<a href="http://example.com"></a>'
+    ),
+    (
+        {},
+        '</ chars',
+        '&lt;/ chars',
     )
 ])
 def test_bleach_html_parser(parser_args, data, expected):

--- a/tests/test_html5lib_shim.py
+++ b/tests/test_html5lib_shim.py
@@ -118,10 +118,11 @@ def test_serializer(data, expected):
         '<a href=\'http://example.com\'\'>',
         '<a href="http://example.com"></a>'
     ),
+    # Test that "expected-closing-tag-but-got-char" works when tags is None
     (
         {},
         '</ chars',
-        '&lt;/ chars',
+        '<!-- chars-->',
     )
 ])
 def test_bleach_html_parser(parser_args, data, expected):


### PR DESCRIPTION
Hi,

I hit this edge case while using `BleachHTMLParser` with `tags=None`. `BleachHTMLTokenizer` will try to iterate `self.parser.tags` if `last_error_token['data'] == 'expected-closing-tag-but-got-char'`.

I've added a test along with the fix. I also had to update the exception string checks in `test_clean.py` since they've changed with pytest 5 update (11 hours ago?).