### PR TITLE
fix for issue #369

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -385,8 +385,10 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                      token['name'].lower() in HTML_TAGS__BLOCK_LEVEL
                      )):
                     _token_data = self._emittedLastToken.get('data', '')
-                    if ((isinstance(_token_data, six.text_type) and
-                         not _token_data.endswith(' '))):
+                    if ((_token_data and
+                         isinstance(_token_data, six.text_type) and
+                         _token_data[-1] not in (' ', '\n', '\t')
+                         )):
                         # BUT, if this is the START of a block level tag, then we
                         # want to insert a space for accessibility.
                         new_data = ' '

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -382,11 +382,14 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                 new_data = ''
                 if ((self._emittedLastToken and
                      token['type'] == TAG_TOKEN_TYPE_START and
-                     token['name'].lower() in HTML_TAGS__BLOCK_LEVEL and
-                     not self._emittedLastToken.get('data', '').endswith(' '))):
-                    # BUT, if this is the START of a block level tag, then we
-                    # want to insert a space for accessibility.
-                    new_data = ' '
+                     token['name'].lower() in HTML_TAGS__BLOCK_LEVEL
+                     )):
+                    _token_data = self._emittedLastToken.get('data', '')
+                    if ((isinstance(_token_data, six.text_type) and
+                         not _token_data.endswith(' '))):
+                        # BUT, if this is the START of a block level tag, then we
+                        # want to insert a space for accessibility.
+                        new_data = ' '
             else:
                 # If we're escaping the token, we want to escape the exact
                 # original string. Since tokenizing also normalizes data

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -384,7 +384,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                      token['type'] == TAG_TOKEN_TYPE_START and
                      token['name'].lower() in HTML_TAGS__BLOCK_LEVEL
                      )):
-                    _token_data = self._emittedLastToken.get('data', '')
+                    _token_data = self._emittedLastToken.get('data', None)
                     if ((_token_data and
                          isinstance(_token_data, six.text_type) and
                          _token_data[-1] not in (' ', '\n', '\t')

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -848,3 +848,12 @@ class TestCleaner:
             cleaner.clean(dirty) ==
             'this is cute! <img rel="moo" src="moo">'
         )
+
+
+def test_strip_respects_block_level_elements():
+    """
+    We should at least have a space between block level elements
+    https://github.com/mozilla/bleach/issues/369
+    """
+    text = '<p>Te<b>st</b>!</p><p>Hello</p>'
+    assert clean(text, tags=[], strip=True) == 'Test! Hello'


### PR DESCRIPTION
This is an attempt at #369.  I am not particularly happy with it, but I could not figure out a better way to handle this.  The start/end tokens are already collapsed by the time we get to any of the sections I would feel more comfortable handling this in.  More tests are needed, but i'll defer that to others.

Changes:
* `HTML_TAGS__BLOCK_LEVEL` contains the list of block level elements
* `InputStreamWithMemory` now tracks the last emitted token, because...
* `InputStreamWithMemory` emits a SPACE instead of no-space if the following conditions are met:
 1. We have already emitted a token; this guards against a leading space.
 2. We are a START token; this guards against a trailing space.
 3. The last emitted token did not end in a space; this guards against double spaces.

