### PR TITLE
Fix semantic whitespace (Issue #369)

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -385,8 +385,10 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                      token['name'].lower() in HTML_TAGS__BLOCK_LEVEL
                      )):
                     _token_data = self._emittedLastToken.get('data', '')
-                    if ((isinstance(_token_data, six.text_type) and
-                         not _token_data.endswith(' '))):
+                    if ((_token_data and
+                         isinstance(_token_data, six.text_type) and
+                         _token_data[-1] not in (' ', '\n', '\t')
+                         )):
                         # BUT, if this is the START of a block level tag, then we
                         # want to insert a space for accessibility.
                         new_data = ' '

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -379,11 +379,6 @@ class BleachHTMLTokenizer(HTMLTokenizer):
              token['type'] in TAG_TOKEN_TYPES and
              token['name'].lower() not in self.parser_tags)):
 
-            # if we strip a tag, keep track of the tag type so whitespace can be
-            # properly added for accessibility. this will be stashed into the
-            # new_token for processing on the next iteration
-            _bleach_stripped = None
-
             # If this is a start/end/empty tag for a tag that's not in our
             # allowed list, then it gets stripped or escaped. In both of these
             # cases it gets converted to a Characters token.
@@ -395,15 +390,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                      token['type'] == TAG_TOKEN_TYPE_START and
                      token['name'].lower() in HTML_TAGS__BLOCK_LEVEL
                      )):
-                    # If this is the START of a "block level" tag, then we
-                    # want to insert a space for accessibility
-                    # this ensures we only do this after a block end tag
-                    if self._emittedLastToken.get('_bleach_stripped') == TAG_TOKEN_TYPE_END:
-                        new_data = '\n'
-                else:
-                    # keep track of this token for the next loop
-                    if token['type'] == TAG_TOKEN_TYPE_END:
-                        _bleach_stripped = TAG_TOKEN_TYPE_END
+                    new_data = '\n'
             else:
                 # If we're escaping the token, we want to escape the exact
                 # original string. Since tokenizing also normalizes data
@@ -415,7 +402,6 @@ class BleachHTMLTokenizer(HTMLTokenizer):
             new_token = {
                 'type': CHARACTERS_TYPE,
                 'data': new_data,
-                '_bleach_stripped': TAG_TOKEN_TYPE_END,  # for next iteration
             }
 
             self.currentToken = self._emittedLastToken = new_token

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -382,11 +382,14 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                 new_data = ''
                 if ((self._emittedLastToken and
                      token['type'] == TAG_TOKEN_TYPE_START and
-                     token['name'].lower() in HTML_TAGS__BLOCK_LEVEL and
-                     not self._emittedLastToken.get('data', '').endswith(' '))):
-                    # BUT, if this is the START of a block level tag, then we
-                    # want to insert a space for accessibility.
-                    new_data = ' '
+                     token['name'].lower() in HTML_TAGS__BLOCK_LEVEL
+                     )):
+                    _token_data = self._emittedLastToken.get('data', '')
+                    if ((isinstance(_token_data, six.text_type) and
+                         not _token_data.endswith(' '))):
+                        # BUT, if this is the START of a block level tag, then we
+                        # want to insert a space for accessibility.
+                        new_data = ' '
             else:
                 # If we're escaping the token, we want to escape the exact
                 # original string. Since tokenizing also normalizes data

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -384,7 +384,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                      token['type'] == TAG_TOKEN_TYPE_START and
                      token['name'].lower() in HTML_TAGS__BLOCK_LEVEL
                      )):
-                    _token_data = self._emittedLastToken.get('data', '')
+                    _token_data = self._emittedLastToken.get('data', None)
                     if ((_token_data and
                          isinstance(_token_data, six.text_type) and
                          _token_data[-1] not in (' ', '\n', '\t')

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -855,8 +855,22 @@ def test_strip_respects_block_level_elements():
     We should at least have a space between block level elements
     https://github.com/mozilla/bleach/issues/369
     """
+    # simple example
     text = '<p>Te<b>st</b>!</p><p>Hello</p>'
-    assert clean(text, tags=[], strip=True) == 'Test! Hello'
+    assert clean(text, tags=[], strip=True) == 'Test!\nHello'
 
+    # with an internal space and escaped character, just to be sure
+    text = '<p>This is our <b>description!</b> &amp;</p><p>nice!</p>'
+    assert clean(text, tags=[], strip=True) == 'This is our description! &amp;\nnice!'
+
+    # a double-wrap causes an initial newline. this can't really be handled under the current design
     text = '<div><p>This is our <b>description!</b> &amp;</p></div><p>nice!</p>'
-    assert clean(text, tags=[], strip=True) == 'This is our description! &amp; nice!'
+    assert clean(text, tags=[], strip=True) == '\nThis is our description! &amp;\nnice!'
+
+    # newlines are used to keep lists and other elements readable
+    text = '<div><p>This is our <b>description!</b> &amp;</p><p>1</p><ul><li>a</li><li>b</li><li>c</li></ul></div><p>nice!</p>'
+    assert clean(text, tags=[], strip=True) == '\nThis is our description! &amp;\n1\n\na\nb\nc\nnice!'
+
+
+
+

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -848,3 +848,12 @@ class TestCleaner:
             cleaner.clean(dirty) ==
             'this is cute! <img rel="moo" src="moo">'
         )
+
+
+def test_strip_respects_block_level_elements():
+    """
+    We should at least have a space between block level elements
+    https://github.com/mozilla/bleach/issues/369
+    """
+    text = '<p>Te<b>st</b>!</p><p>Hello</p>'
+    assert clean(text, tags=[], strip=True) == 'Test! Hello'

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -857,3 +857,6 @@ def test_strip_respects_block_level_elements():
     """
     text = '<p>Te<b>st</b>!</p><p>Hello</p>'
     assert clean(text, tags=[], strip=True) == 'Test! Hello'
+
+    text = '<div><p>This is our <b>description!</b> &amp;</p></div><p>nice!</p>'
+    assert clean(text, tags=[], strip=True) == 'This is our description! &amp; nice!'


### PR DESCRIPTION
After testing with many edge-cases, I decided two things:

1. minimizing whitespace is far too difficult due to the design of this package.  the 'stripping' of tags occurs in a place that can not look backwards enough and can not access the 'content' without a large redesign

2. the whitespace should be a newline, not a space (as suggested in #369). this is because content becomes too confusing to understand with a "space" (such as list elements)