### PR TITLE
Make the documentation reproducible

### DIFF
--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -49,7 +49,7 @@ def build_url_re(tlds=TLDS, protocols=html5lib_shim.allowed_protocols):
         (?:[/?][^\s\{{\}}\|\\\^\[\]`<>"]*)?
             # /path/zz (excluding "unsafe" chars from RFC 1738,
             # except for # and ~, which happen in practice)
-        """.format('|'.join(protocols), '|'.join(tlds)),
+        """.format('|'.join(sorted(protocols)), '|'.join(sorted(tlds))),
         re.IGNORECASE | re.VERBOSE | re.UNICODE)
 
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that python-bleach could not be built reproducibly.

This is because the documentation included a default arguments that was (originally) generated from a `frozenset` type which are iterated over at runtime in a nondeterministic order.

This commit therefore ensures a regular expression is constructed in a deterministic manner, rendering the documentation reproducible.

This bug was originally filed in Debian as [#934120](https://bugs.debian.org/934120).