### PR TITLE
Stop using deprecated Travis container environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Note: If you update this, make sure to update tox.ini, too.
 dist: xenial
-sudo: false
 language: python
 cache:
   directories:


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Carries #468 without merging master back into the feature branch.