### PR TITLE
Correct typo: bleach.clean(user_bio} → bleach.clean(user_bio)

### DIFF
--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -34,7 +34,7 @@ return ``unicode``.
 
    This is a **not safe** use of ``clean`` output in an HTML attribute::
 
-     <body data-bio="{{ bleach.clean(user_bio} }}">
+     <body data-bio="{{ bleach.clean(user_bio) }}">
 
 
    If you need to use the output of ``bleach.clean()`` in an HTML attribute, you

--- a/docs/goals.rst
+++ b/docs/goals.rst
@@ -90,7 +90,7 @@ For example, this is a safe use of ``clean`` output in an HTML context::
 
 This is a **not safe** use of ``clean`` output in an HTML attribute::
 
-    <body data-bio="{{ bleach.clean(user_bio} }}">
+    <body data-bio="{{ bleach.clean(user_bio) }}">
 
 
 If you need to use the output of ``bleach.clean()`` in an HTML attribute, you


### PR DESCRIPTION
Carries #454 without merging master back into the feature branch. Previously reviewed in that PR.