### PR TITLE
docs: Add linkify Linker examples using custom TLDs and protocols

### DIFF
--- a/docs/linkify.rst
+++ b/docs/linkify.rst
@@ -349,6 +349,21 @@ domains (TLDs) and URL protocols/schemes:
    'https links <a href="https://example.com/" rel="nofollow">https://example.com/</a>'
 
 
+Specify localized TLDs with and without punycode encoding to handle
+both formats:
+
+.. doctest::
+
+   >>> from bleach.linkifier import Linker, build_url_re
+
+   >>> linker = Linker(url_re=build_url_re(tlds=['рф']))
+   >>> linker.linkify('https://xn--80aaksdi3bpu.xn--p1ai/ https://дайтрафик.рф/')
+   'https://xn--80aaksdi3bpu.xn--p1ai/ <a href="https://дайтрафик.рф/" rel="nofollow">https://дайтрафик.рф/</a>'
+
+   >>> puny_linker = Linker(url_re=build_url_re(tlds=['рф', 'xn--p1ai']))
+   >>> puny_linker.linkify('https://xn--80aaksdi3bpu.xn--p1ai/ https://дайтрафик.рф/')
+   '<a href="https://xn--80aaksdi3bpu.xn--p1ai/" rel="nofollow">https://xn--80aaksdi3bpu.xn--p1ai/</a> <a href="https://дайтрафик.рф/" rel="nofollow">https://дайтрафик.рф/</a>'
+
 :ref:`LinkifyFilter <linkify-LinkifyFilter>` also accepts these options.
 
 .. autoclass:: bleach.linkifier.Linker

--- a/docs/linkify.rst
+++ b/docs/linkify.rst
@@ -324,6 +324,33 @@ instance.
    'a b c <a href="http://example.com" rel="nofollow">http://example.com</a> d e f'
 
 
+It includes optional keyword arguments to specify allowed top-level
+domains (TLDs) and URL protocols/schemes:
+
+.. doctest::
+
+   >>> from bleach.linkifier import Linker, build_url_re
+
+   >>> only_fish_tld_url_re = build_url_re(tlds=['fish'])
+   >>> linker = Linker(url_re=only_fish_tld_url_re)
+
+   >>> linker.linkify('com TLD does not link https://example.com')
+   'com TLD does not link https://example.com'
+   >>> linker.linkify('fish TLD links https://example.fish')
+   'fish TLD links <a href="https://example.fish" rel="nofollow">https://example.fish</a>'
+
+
+   >>> only_https_url_re = build_url_re(protocols=['https'])
+   >>> linker = Linker(url_re=only_https_url_re)
+
+   >>> linker.linkify('gopher does not link gopher://example.link')
+   'gopher does not link gopher://example.link'
+   >>> linker.linkify('https links https://example.com/')
+   'https links <a href="https://example.com/" rel="nofollow">https://example.com/</a>'
+
+
+:ref:`LinkifyFilter <linkify-LinkifyFilter>` also accepts these options.
+
 .. autoclass:: bleach.linkifier.Linker
    :members:
 


### PR DESCRIPTION
fixes: #472 see the linked issues for additional info.

Surfaces the `build_url_re` docstring and adds a couple examples to the docs. One possible downside is if we move away from the `url_re` kwarg then it'll break backwards compatibility, but I think that's OK.

r? @jdufresne or @willkg