### PR TITLE
require pytest 5+ and update exception handling tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -e .
 
 # Requirements to run the test suite
-pytest
+pytest<5
 pytest-wholenodeid
 flake8
 tox


### PR DESCRIPTION
force pytest <5 to workaround #459 #467 and I'll make a new issue for supporting / upgrading to pytest 5+ (edit: done in #475)

r? @jdufresne 