### PR TITLE
Fix tox.ini to run doctests in docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: MODE=vendorverify
     - python: "3.4"
       env: MODE=lint
-    - python: "3.5"
+    - python: "3.6"
       env: MODE=docs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       env: MODE=vendorverify
     - python: "3.4"
       env: MODE=lint
+    - python: "3.5"
+      env: MODE=docs
 
 script:
   - ./scripts/run_tests.sh $MODE

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -16,6 +16,8 @@ case "${MODE}" in
     flake8 bleach/ ;;
   vendorverify)
     ./scripts/vendor_verify.sh ;;
+  docs)
+    tox -e docs ;;
   *)
     echo "Unknown mode $MODE."
     exit 1

--- a/tox.ini
+++ b/tox.ini
@@ -68,3 +68,4 @@ deps =
     -rrequirements-dev.txt
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/doctest


### PR DESCRIPTION
This fixes `tox.ini` to run doctests with the `docs` environment. You can run it manually like this:

```
$ tox -e docs
```

I also tweaked the CI setup to build the docs and run doctests in CI. I think that'll work.