### PR TITLE
Support pytest5 syntax for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs/_build/
 *~
 *.swp
 __pycache__
+venv/
+.idea/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -e .
 
 # Requirements to run the test suite
-pytest<5
+pytest
 pytest-wholenodeid
 flake8
 tox

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -24,11 +24,11 @@ def test_only_text_is_cleaned():
 
     with pytest.raises(TypeError) as e:
         clean(some_type)
-    assert "argument cannot be of 'type' type" in str(e)
+    assert "argument cannot be of 'type' type" in str(e.value)
 
     with pytest.raises(TypeError) as e:
         clean(no_type)
-    assert "NoneType" in str(e)
+    assert "NoneType" in str(e.value)
 
 
 def test_empty():


### PR DESCRIPTION
Tox test with python 2.7 and 3.7 passed (python 3.7 gave warning for html5lib - external library).
Don't know what was the issue with python 2.7 before, but just making these 2 changes worked in both. I was going to add a solution for python 2 case, but it wasn't needed.

Fixes #459
Fixes #475