### PR TITLE
Remove references to IRC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,6 @@ fixes. You can find full documentation on `ReadTheDocs`_.
 :Code:           https://github.com/mozilla/bleach
 :Documentation:  https://bleach.readthedocs.io/
 :Issue tracker:  https://github.com/mozilla/bleach/issues
-:IRC:            ``#bleach`` on irc.mozilla.org
 :License:        Apache License v2; see LICENSE file
 
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -102,4 +102,4 @@ Release process
 
     That will push the release to PyPI.
 
-12. Blog posts, twitter, update topic in ``#bleach``, etc.
+12. Blog posts, twitter, etc.


### PR DESCRIPTION
Mozilla is shutting down irc.mozilla.org soon. We should stop talking about the IRC channel.

Fixes #482