### PR TITLE
Fix collections ABCs deprecation warning

### DIFF
--- a/bleach/_vendor/html5lib/_trie/_base.py
+++ b/bleach/_vendor/html5lib/_trie/_base.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import Mapping
+try:
+    # Python 3
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2.7
+    from collections import Mapping
 
 
 class Trie(Mapping):


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping