### PR TITLE
only install six for python2 versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'six>=1.9.0',
+    'six>=1.9.0;python_version<"3"',
     # html5lib requirements
     'webencodings',
 ]


### PR DESCRIPTION
I noticed that for my application running python 3.6 that installing bleach was still installing six, which is not needed. This PR modifies the setup arguments to match the [setuptools docs](https://setuptools.readthedocs.io/en/latest/setuptools.html#id17) for declaring platform specific dependencies.

Let me know what you think and if there's anything else I can do here :)