### PR TITLE
Travis CI: test on PyPy 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "pypy2.7-6.0"
-  - "pypy3.5-6.0"
+  - "pypy"
+  - "pypy3"
 
 install:
   - pip install -U pip setuptools>=18.5


### PR DESCRIPTION
Plain `pypy` and `pypy3` now point to PyPy 7.1.1.