### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -25,7 +24,7 @@ matrix:
       env: MODE=lint
     - python: "2.7"
       env: MODE=vendorverify
-    - python: "3.4"
+    - python: "3.8"
       env: MODE=lint
     - python: "3.6"
       env: MODE=docs

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     package_data={'': ['README.rst']},
     zip_safe=False,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=install_requires,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -56,7 +56,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 
 [tox]
 envlist =
-    py{27,34,35,36,37,38,py,py3}
-    py{27,34,35,36,37,38}-build-no-lang
+    py{27,35,36,37,38,py,py3}
+    py{27,35,36,37,38}-build-no-lang
     docs
     lint
     vendorverify
@@ -16,12 +16,6 @@ commands =
     python setup.py build
 
 [testenv:py27-build-no-lang]
-setenv =
-    LANG=
-commands =
-    python setup.py build
-
-[testenv:py34-build-no-lang]
 setenv =
     LANG=
 commands =


### PR DESCRIPTION
Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for bleach from PyPI for December 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 2.7      |  45.22% | 2,184,849 |
| 3.6      |  24.90% | 1,203,109 |
| 3.7      |  17.44% |   842,550 |
| 3.5      |   9.00% |   434,677 |
| 3.8      |   2.53% |   122,121 |
| 3.4      |   0.65% |    31,312 |
| null     |   0.26% |    12,381 |
| 3.9      |   0.01% |       342 |
| 3.3      |   0.00% |        20 |
| 2.6      |   0.00% |        12 |
| 3.1      |   0.00% |         1 |
| Total    |         | 4,831,374 |

Source: `pip install -U pypistats && pypistats python_minor bleach --last-month`

