### PR TITLE
Update for v3.1.3 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,33 @@
 Bleach changes
 ==============
 
+Version 3.1.3 (March 17th, 2020)
+--------------------------------
+
+**Security fixes**
+
+None
+
+**Backwards incompatible changes**
+
+None
+
+**Features**
+
+* Add relative link to code of conduct. (#442)
+
+* Drop deprecated 'setup.py test' support. (#507)
+
+* Fix typo: curren -> current in tests/test_clean.py (#504)
+
+* Test on PyPy 7
+
+* Drop test support for end of life Python 3.4
+
+**Bug fixes**
+
+None
+
 Version 3.1.2 (March 11th, 2020)
 --------------------------------
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,12 +1,13 @@
 Bleach was originally written and maintained by James Socol and various
 contributors within and without the Mozilla Corporation and Foundation.
 
-It is currently maintained by Will Kahn-Greene an Greg Guthe.
+It is currently maintained by Will Kahn-Greene, Greg Guthe, and Jon Dufresne.
 
 Maintainers:
 
 - Will Kahn-Greene <willkg@mozilla.com>
 - Greg Guthe <gguthe@mozilla.com>
+- Jon Dufresne <jon.dufresne@gmail.com>
 
 Maintainer emeritus:
 
@@ -32,6 +33,7 @@ Contributors:
 - Chris Beaven
 - Dan Gayle
 - dave-shawley
+- dbxnr
 - Erik Rose
 - Gaurav Dadhania
 - Geoffrey Sneddon
@@ -44,6 +46,7 @@ Contributors:
 - Janusz Kamieński
 - Jeff Balogh
 - Jonathan Vanasco
+- Jon Dufresne
 - Lee, Cheon-il
 - Les Orchard
 - Lorenz Schori
@@ -65,6 +68,7 @@ Contributors:
 - Stu Cox
 - Tim Dumol
 - Timothy Fitz
+- Tim Gates
 - Vadim Kotov
 - Vitaly Volkov
 - Will Kahn-Greene

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -18,9 +18,9 @@ from bleach.sanitizer import (
 
 
 # yyyymmdd
-__releasedate__ = '20200311'
+__releasedate__ = '20200317'
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = '3.1.2'
+__version__ = '3.1.3'
 VERSION = parse_version(__version__)
 
 


### PR DESCRIPTION
Currently, we're maintaining as separate v3.1 branch confusingly called [v3.1.0-branch](https://github.com/mozilla/bleach/tree/v3.1.0-branch) for security releases. 

This PR gets the two branches in sync for a 3.1.3 release and to cut future releases from master.

I'm open to alternate branching and development schemes too.