### PR TITLE
Replace setuptools dependency with packaging.

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from pkg_resources import parse_version
+import packaging.version
 
 from bleach.linkifier import (
     DEFAULT_CALLBACKS,
@@ -21,7 +21,7 @@ from bleach.sanitizer import (
 __releasedate__ = '20200324'
 # x.y.z or x.y.z.dev0 -- semver
 __version__ = '3.1.4'
-VERSION = parse_version(__version__)
+VERSION = packaging.version.Version(__version__)
 
 
 __all__ = ['clean', 'linkify']

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
+    'packaging',
     'six>=1.9.0',
     # html5lib requirements
     'webencodings',


### PR DESCRIPTION
bleach had a (undeclared) dependency on setuptools via the import of pkg_resources in __init__.py. pkg_resources is mostly deprecated, and its use should be avoided. For bleach's usage, we can directly employ the packaging library.