### PR TITLE
Update html5lib to Py3 Mapping import

### DIFF
--- a/bleach/_vendor/html5lib/_trie/_base.py
+++ b/bleach/_vendor/html5lib/_trie/_base.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python 2.7
+    from collections import Mapping
 
 
 class Trie(Mapping):


### PR DESCRIPTION
The bleach project uses html5lib 1.0.1 - the latest version on pypi - however this generates a deprecation warning for the Mapping import in bleach/_vendor/html5lib/_trie/_base.py

This pull request updates the import to the python 3.3+ form while maintaining backwards compatibility as per https://github.com/html5lib/html5lib-python/blob/master/html5lib/_trie/_base.py#L3
 