### PR TITLE
Add style attr sanitizer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,21 @@
 Bleach changes
 ==============
 
+Version 3.2.0.dev0 (May 15th, 2020)
+-----------------------------------
+
+**Security fixes**
+
+None
+
+**Features**
+
+* Add ``css_style_attr_sanitizer`` argument to ``bleach.sanitizer.Cleaner``
+
+**Bug fixes**
+
+None
+
 Version 3.1.5 (April 29th, 2020)
 --------------------------------
 

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -18,9 +18,9 @@ from bleach.sanitizer import (
 
 
 # yyyymmdd
-__releasedate__ = '20200429'
+__releasedate__ = '20200515'
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = '3.1.5'
+__version__ = '3.2.0.dev0'
 VERSION = packaging.version.Version(__version__)
 
 

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -107,7 +107,7 @@ class Cleaner(object):
 
         :arg list filters: list of html5lib Filter classes to pass streamed content through
 
-            .. seealso:: http://html5lib.readthedocs.io/en/latest/movingparts.html#filters
+            .. seealso:: https://html5lib.readthedocs.io/en/latest/movingparts.html#filters
 
             .. Warning::
 

--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -395,3 +395,32 @@ use an html5lib filter.
 
 
 .. versionadded:: 2.0
+
+
+Using different CSS parser and sanitizer with `css_style_attr_sanitizer`
+------------------------------------------------------------------------
+
+The argument `css_style_attr_sanitizer` can ``bleach.sanitizer.Cleaner`` be used
+to customize CSS parsing and sanitization. For example, define a new sanitization
+function:
+
+   >>> from bleach import Cleaner
+
+   >>> def sanitize_css(style):
+   ...     print('ignoring style attribute value:', repr(style))
+   ...     return ''
+
+   Create a new :py:class:`bleach.sanitizer.Cleaner` using it:
+
+   >>> cleaner = Cleaner(
+   ...     tags=['p'],
+   ...     attributes=['style'],
+   ...     styles=['not used'],
+   ...     css_style_attr_sanitizer=sanitize_css,
+   ... )
+
+   >>> cleaner.clean('<p style="cursor: -moz-grab;">bar</p>')
+   ignoring style attribute value: 'cursor: -moz-grab;'
+   '<p style="">bar</p>'
+
+.. versionadded:: 3.2.0

--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -346,7 +346,7 @@ This lets you add data, drop data and change data as it is being serialized back
 to a unicode.
 
 Documentation on html5lib Filters is here:
-http://html5lib.readthedocs.io/en/latest/movingparts.html#filters
+https://html5lib.readthedocs.io/en/latest/movingparts.html#filters
 
 Trivial Filter example:
 

--- a/docs/goals.rst
+++ b/docs/goals.rst
@@ -158,7 +158,7 @@ Usage with Javascript frameworks and template languages
 -------------------------------------------------------
 
 A number of Javascript frameworks and template languages allow `XSS
-via Javascript Gadgets <http://sebastian-lekies.de/slides/appsec2017.pdf>`_.
+via Javascript Gadgets <https://sebastian-lekies.de/slides/appsec2017.pdf>`_.
 While Bleach usually produces output safe for these contexts, it is
 not tested against them nor guaranteed to produce safe output.  Check
 that bleach properly strips or escapes language-specific syntax like

--- a/docs/goals.rst
+++ b/docs/goals.rst
@@ -133,10 +133,26 @@ Bleach to make it safe and then do your own transform afterwards.
 Allow arbitrary styling
 -----------------------
 
-There are a number of interesting CSS properties that can do dangerous things,
-like Opera's ``-o-link``. Painful as it is, if you want your users to be able to
-change nearly anything in a ``style`` attribute, you should have to opt into
-this.
+Arbitrary CSS can do dangerous things:
+
+* `UI Redressing / Clickjacking <https://html5sec.org/#clickjacking>`_
+  using positioning and other properties (e.g. ``pointer-events``,
+  ``z-index``, ``display: none``, ``position: absolute``, etc.)
+
+* `data exfiltration
+  <https://www.mike-gualtieri.com/posts/stealing-data-with-css-attack-and-defense>`_
+  / `privacy leaks <https://github.com/cure53/HTTPLeaks/blob/ac0a2c6c8bd73c4e982c6fce86d01d018571b17e/leak.html#L362-L396>`_
+
+* `XSS in legacy browsers <https://blog.innerht.ml/cascading-style-scripting/>`_ using properties like ``-o-link`` and
+  ``-moz-binding``, or functions like ``expression()`` and ``url()``
+
+
+Bleach doesn't know how the surrounding page is styled or what a
+site's authors or users consider customization instead of defacement.
+
+Consequently, bleach requires you to opt in if you want your users to
+be able to change nearly anything in a ``style`` attribute.
+
 
 Usage with Javascript frameworks and template languages
 -------------------------------------------------------

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -5,7 +5,7 @@ from timeit import timeit
 
 import pytest
 
-from bleach import clean
+from bleach import Cleaner, clean
 
 
 clean = partial(clean, tags=['p'], attributes=['style'])
@@ -244,3 +244,23 @@ def test_css_parsing_gauntlet_regex_backtracking(overlap_test_char):
 
     # should complete in less than one second
     assert time_clean(overlap_test_char, 22) < 1.0
+
+
+def always_red_sanitizer(style):
+    return 'color: red'
+
+
+@pytest.mark.parametrize('data, styles, expected', [
+    (
+        '<p style="border: 1px solid blue; color: blue; float: left;">bar</p>',
+        [],
+        '<p style="color: red">bar</p>'
+    ),
+])
+def test_custom_css_sanitizer(data, styles, expected):
+    custom_cleaner = Cleaner(
+        tags=['p'], attributes=['style'],
+        styles=styles,
+        css_style_attr_sanitizer=always_red_sanitizer,
+    )
+    assert custom_cleaner.clean(data) == expected


### PR DESCRIPTION
As discussed in #248, we'd like to move away from the regex based CSS sanitizer but don't necessarily have a maintained CSS parser with Python 2 support to switch to (also some users don't necessarily want full CSS parsing).

Changes in this PR:

* add a `css_style_attr_sanitizer` param/arg to bleach `Cleaner` and `BleachSanitizerFilter` to make it possible to override `sanitize_css` without changing `Cleaner.clean`
* update the arbitrary style goal

We'd then cut a major release that:

* drops python 2 support #520
* replaces old regex based stuff with tinycss2 #248


r? @jdufresne 

cc @willkg @peterbe 