### PR TITLE
Update for v3.2.0 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,8 @@
 Bleach changes
 ==============
 
-Version Unreleased (replaceme, 2020)
---------------------------------
+Version 3.2.0 (September 16th, 2020)
+------------------------------------
 
 **Security fixes**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.1.x   | :white_check_mark: |
+| 3.2.x   | :white_check_mark: |
 | < 3.1   | :x:                |
 
 ## Reporting a Vulnerability

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -18,9 +18,9 @@ from bleach.sanitizer import (
 
 
 # yyyymmdd
-__releasedate__ = 'replaceme'
+__releasedate__ = '20200916'
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = '3.2.0dev1'
+__version__ = '3.2.0'
 VERSION = packaging.version.Version(__version__)
 
 


### PR DESCRIPTION
https://github.com/mozilla/bleach/blob/master/docs/dev.rst

no changes to manifest.in

- [x] tox passes
- [x] `make docs` passes
- [x] `make doctest` passes (NB: fails on 2.7 due to unicode str literals)
