### PR TITLE
paint it black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ matrix:
       env: MODE=vendorverify
     - python: "3.8"
       env: MODE=lint
+    - python: "3.8"
+      env: MODE=format-check
+      install:
+        - pip install -U pip setuptools>=18.5
+        - pip install -r requirements-dev.txt
+        - pip install -U black
     - python: "3.6"
       env: MODE=docs
 

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -18,18 +18,24 @@ from bleach.sanitizer import (
 
 
 # yyyymmdd
-__releasedate__ = ''
+__releasedate__ = ""
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = '3.2.1dev0'
+__version__ = "3.2.1dev0"
 VERSION = packaging.version.Version(__version__)
 
 
-__all__ = ['clean', 'linkify']
+__all__ = ["clean", "linkify"]
 
 
-def clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-          styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
-          strip_comments=True):
+def clean(
+    text,
+    tags=ALLOWED_TAGS,
+    attributes=ALLOWED_ATTRIBUTES,
+    styles=ALLOWED_STYLES,
+    protocols=ALLOWED_PROTOCOLS,
+    strip=False,
+    strip_comments=True,
+):
     """Clean an HTML fragment of malicious content and return it
 
     This function is a security-focused function whose sole purpose is to
@@ -123,9 +129,5 @@ def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_tags=None, parse_email=False
     :returns: linkified text as unicode
 
     """
-    linker = Linker(
-        callbacks=callbacks,
-        skip_tags=skip_tags,
-        parse_email=parse_email
-    )
+    linker = Linker(callbacks=callbacks, skip_tags=skip_tags, parse_email=parse_email)
     return linker.linkify(text)

--- a/bleach/callbacks.py
+++ b/bleach/callbacks.py
@@ -3,31 +3,31 @@ from __future__ import unicode_literals
 
 
 def nofollow(attrs, new=False):
-    href_key = (None, 'href')
+    href_key = (None, "href")
 
     if href_key not in attrs:
         return attrs
 
-    if attrs[href_key].startswith('mailto:'):
+    if attrs[href_key].startswith("mailto:"):
         return attrs
 
-    rel_key = (None, 'rel')
-    rel_values = [val for val in attrs.get(rel_key, '').split(' ') if val]
-    if 'nofollow' not in [rel_val.lower() for rel_val in rel_values]:
-        rel_values.append('nofollow')
-    attrs[rel_key] = ' '.join(rel_values)
+    rel_key = (None, "rel")
+    rel_values = [val for val in attrs.get(rel_key, "").split(" ") if val]
+    if "nofollow" not in [rel_val.lower() for rel_val in rel_values]:
+        rel_values.append("nofollow")
+    attrs[rel_key] = " ".join(rel_values)
 
     return attrs
 
 
 def target_blank(attrs, new=False):
-    href_key = (None, 'href')
+    href_key = (None, "href")
 
     if href_key not in attrs:
         return attrs
 
-    if attrs[href_key].startswith('mailto:'):
+    if attrs[href_key].startswith("mailto:"):
         return attrs
 
-    attrs[(None, 'target')] = '_blank'
+    attrs[(None, "target")] = "_blank"
     return attrs

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -42,129 +42,129 @@ ENTITIES_TRIE = Trie(ENTITIES)
 
 #: Token type constants--these never change
 TAG_TOKEN_TYPES = {
-    constants.tokenTypes['StartTag'],
-    constants.tokenTypes['EndTag'],
-    constants.tokenTypes['EmptyTag']
+    constants.tokenTypes["StartTag"],
+    constants.tokenTypes["EndTag"],
+    constants.tokenTypes["EmptyTag"],
 }
-CHARACTERS_TYPE = constants.tokenTypes['Characters']
-PARSEERROR_TYPE = constants.tokenTypes['ParseError']
+CHARACTERS_TYPE = constants.tokenTypes["Characters"]
+PARSEERROR_TYPE = constants.tokenTypes["ParseError"]
 
 
 #: List of valid HTML tags, from WHATWG HTML Living Standard as of 2018-10-17
 #: https://html.spec.whatwg.org/multipage/indices.html#elements-3
 HTML_TAGS = [
-    'a',
-    'abbr',
-    'address',
-    'area',
-    'article',
-    'aside',
-    'audio',
-    'b',
-    'base',
-    'bdi',
-    'bdo',
-    'blockquote',
-    'body',
-    'br',
-    'button',
-    'canvas',
-    'caption',
-    'cite',
-    'code',
-    'col',
-    'colgroup',
-    'data',
-    'datalist',
-    'dd',
-    'del',
-    'details',
-    'dfn',
-    'dialog',
-    'div',
-    'dl',
-    'dt',
-    'em',
-    'embed',
-    'fieldset',
-    'figcaption',
-    'figure',
-    'footer',
-    'form',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'head',
-    'header',
-    'hgroup',
-    'hr',
-    'html',
-    'i',
-    'iframe',
-    'img',
-    'input',
-    'ins',
-    'kbd',
-    'keygen',
-    'label',
-    'legend',
-    'li',
-    'link',
-    'map',
-    'mark',
-    'menu',
-    'meta',
-    'meter',
-    'nav',
-    'noscript',
-    'object',
-    'ol',
-    'optgroup',
-    'option',
-    'output',
-    'p',
-    'param',
-    'picture',
-    'pre',
-    'progress',
-    'q',
-    'rp',
-    'rt',
-    'ruby',
-    's',
-    'samp',
-    'script',
-    'section',
-    'select',
-    'slot',
-    'small',
-    'source',
-    'span',
-    'strong',
-    'style',
-    'sub',
-    'summary',
-    'sup',
-    'table',
-    'tbody',
-    'td',
-    'template',
-    'textarea',
-    'tfoot',
-    'th',
-    'thead',
-    'time',
-    'title',
-    'tr',
-    'track',
-    'u',
-    'ul',
-    'var',
-    'video',
-    'wbr',
+    "a",
+    "abbr",
+    "address",
+    "area",
+    "article",
+    "aside",
+    "audio",
+    "b",
+    "base",
+    "bdi",
+    "bdo",
+    "blockquote",
+    "body",
+    "br",
+    "button",
+    "canvas",
+    "caption",
+    "cite",
+    "code",
+    "col",
+    "colgroup",
+    "data",
+    "datalist",
+    "dd",
+    "del",
+    "details",
+    "dfn",
+    "dialog",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "embed",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "head",
+    "header",
+    "hgroup",
+    "hr",
+    "html",
+    "i",
+    "iframe",
+    "img",
+    "input",
+    "ins",
+    "kbd",
+    "keygen",
+    "label",
+    "legend",
+    "li",
+    "link",
+    "map",
+    "mark",
+    "menu",
+    "meta",
+    "meter",
+    "nav",
+    "noscript",
+    "object",
+    "ol",
+    "optgroup",
+    "option",
+    "output",
+    "p",
+    "param",
+    "picture",
+    "pre",
+    "progress",
+    "q",
+    "rp",
+    "rt",
+    "ruby",
+    "s",
+    "samp",
+    "script",
+    "section",
+    "select",
+    "slot",
+    "small",
+    "source",
+    "span",
+    "strong",
+    "style",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "template",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "title",
+    "tr",
+    "track",
+    "u",
+    "ul",
+    "var",
+    "video",
+    "wbr",
 ]
 
 
@@ -175,6 +175,7 @@ class InputStreamWithMemory(object):
     since the last < which marked an open tag state.
 
     """
+
     def __init__(self, inner_stream):
         self._inner_stream = inner_stream
         self.reset = self._inner_stream.reset
@@ -218,7 +219,7 @@ class InputStreamWithMemory(object):
         is the "tag" that is being tokenized.
 
         """
-        return six.text_type('').join(self._buffer)
+        return six.text_type("").join(self._buffer)
 
     def start_tag(self):
         """Resets stream history to just '<'
@@ -227,11 +228,12 @@ class InputStreamWithMemory(object):
         open tag. Any time we see that, we reset the buffer.
 
         """
-        self._buffer = ['<']
+        self._buffer = ["<"]
 
 
 class BleachHTMLTokenizer(HTMLTokenizer):
     """Tokenizer that doesn't consume character entities"""
+
     def __init__(self, consume_entities=False, **kwargs):
         super(BleachHTMLTokenizer, self).__init__(**kwargs)
 
@@ -245,9 +247,11 @@ class BleachHTMLTokenizer(HTMLTokenizer):
 
         for token in super(BleachHTMLTokenizer, self).__iter__():
             if last_error_token is not None:
-                if ((last_error_token['data'] == 'invalid-character-in-attribute-name' and
-                     token['type'] in TAG_TOKEN_TYPES and
-                     token.get('data'))):
+                if (
+                    last_error_token["data"] == "invalid-character-in-attribute-name"
+                    and token["type"] in TAG_TOKEN_TYPES
+                    and token.get("data")
+                ):
                     # token["data"] is an html5lib attributeMap
                     # (OrderedDict 3.7+ and dict otherwise)
                     # of attr name to attr value
@@ -266,9 +270,11 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                     last_error_token = None
                     yield token
 
-                elif ((last_error_token['data'] == 'expected-closing-tag-but-got-char' and
-                       self.parser.tags is not None and
-                       token['data'].lower().strip() not in self.parser.tags)):
+                elif (
+                    last_error_token["data"] == "expected-closing-tag-but-got-char"
+                    and self.parser.tags is not None
+                    and token["data"].lower().strip() not in self.parser.tags
+                ):
                     # We've got either a malformed tag or a pseudo-tag or
                     # something that html5lib wants to turn into a malformed
                     # comment which Bleach clean() will drop so we interfere
@@ -280,13 +286,13 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                     #
                     # If this is not an allowed tag, then we convert it to
                     # characters and it'll get escaped in the sanitizer.
-                    token['data'] = self.stream.get_tag()
-                    token['type'] = CHARACTERS_TYPE
+                    token["data"] = self.stream.get_tag()
+                    token["type"] = CHARACTERS_TYPE
 
                     last_error_token = None
                     yield token
 
-                elif token['type'] == PARSEERROR_TYPE:
+                elif token["type"] == PARSEERROR_TYPE:
                     # If the token is a parse error, then let the last_error_token
                     # go, and make token the new last_error_token
                     yield last_error_token
@@ -301,7 +307,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
 
             # If the token is a ParseError, we hold on to it so we can get the
             # next token and potentially fix it.
-            if token['type'] == PARSEERROR_TYPE:
+            if token["type"] == PARSEERROR_TYPE:
                 last_error_token = token
                 continue
 
@@ -314,7 +320,9 @@ class BleachHTMLTokenizer(HTMLTokenizer):
         # If this tokenizer is set to consume entities, then we can let the
         # superclass do its thing.
         if self.consume_entities:
-            return super(BleachHTMLTokenizer, self).consumeEntity(allowedChar, fromAttribute)
+            return super(BleachHTMLTokenizer, self).consumeEntity(
+                allowedChar, fromAttribute
+            )
 
         # If this tokenizer is set to not consume entities, then we don't want
         # to consume and convert them, so this overrides the html5lib tokenizer's
@@ -323,10 +331,10 @@ class BleachHTMLTokenizer(HTMLTokenizer):
         # However, when that gets called, it's consumed an &, so we put that back in
         # the stream.
         if fromAttribute:
-            self.currentToken['data'][-1][1] += '&'
+            self.currentToken["data"][-1][1] += "&"
 
         else:
-            self.tokenQueue.append({"type": CHARACTERS_TYPE, "data": '&'})
+            self.tokenQueue.append({"type": CHARACTERS_TYPE, "data": "&"})
 
     def tagOpenState(self):
         # This state marks a < that is either a StartTag, EndTag, EmptyTag,
@@ -339,16 +347,18 @@ class BleachHTMLTokenizer(HTMLTokenizer):
     def emitCurrentToken(self):
         token = self.currentToken
 
-        if ((self.parser.tags is not None and
-             token['type'] in TAG_TOKEN_TYPES and
-             token['name'].lower() not in self.parser.tags)):
+        if (
+            self.parser.tags is not None
+            and token["type"] in TAG_TOKEN_TYPES
+            and token["name"].lower() not in self.parser.tags
+        ):
             # If this is a start/end/empty tag for a tag that's not in our
             # allowed list, then it gets stripped or escaped. In both of these
             # cases it gets converted to a Characters token.
             if self.parser.strip:
                 # If we're stripping the token, we just throw in an empty
                 # string token.
-                new_data = ''
+                new_data = ""
 
             else:
                 # If we're escaping the token, we want to escape the exact
@@ -358,10 +368,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                 # string and use that.
                 new_data = self.stream.get_tag()
 
-            new_token = {
-                'type': CHARACTERS_TYPE,
-                'data': new_data
-            }
+            new_token = {"type": CHARACTERS_TYPE, "data": new_data}
 
             self.currentToken = new_token
             self.tokenQueue.append(new_token)
@@ -373,6 +380,7 @@ class BleachHTMLTokenizer(HTMLTokenizer):
 
 class BleachHTMLParser(HTMLParser):
     """Parser that uses BleachHTMLTokenizer"""
+
     def __init__(self, tags, strip, consume_entities, **kwargs):
         """
         :arg tags: list of allowed tags--everything else is either stripped or
@@ -388,7 +396,9 @@ class BleachHTMLParser(HTMLParser):
         self.consume_entities = consume_entities
         super(BleachHTMLParser, self).__init__(**kwargs)
 
-    def _parse(self, stream, innerHTML=False, container='div', scripting=True, **kwargs):
+    def _parse(
+        self, stream, innerHTML=False, container="div", scripting=True, **kwargs
+    ):
         # set scripting=True to parse <noscript> as though JS is enabled to
         # match the expected context in browsers
         #
@@ -399,10 +409,7 @@ class BleachHTMLParser(HTMLParser):
         self.container = container
         self.scripting = scripting
         self.tokenizer = BleachHTMLTokenizer(
-            stream=stream,
-            consume_entities=self.consume_entities,
-            parser=self,
-            **kwargs
+            stream=stream, consume_entities=self.consume_entities, parser=self, **kwargs
         )
         self.reset()
 
@@ -424,8 +431,8 @@ def convert_entity(value):
         doesn't match a character entity
 
     """
-    if value[0] == '#':
-        if value[1] in ('x', 'X'):
+    if value[0] == "#":
+        if value[1] in ("x", "X"):
             return six.unichr(int(value[2:], 16))
         return six.unichr(int(value[1:], 10))
 
@@ -440,7 +447,7 @@ def convert_entities(text):
     :returns: unicode text with converted entities
 
     """
-    if '&' not in text:
+    if "&" not in text:
         return text
 
     new_text = []
@@ -448,7 +455,7 @@ def convert_entities(text):
         if not part:
             continue
 
-        if part.startswith('&'):
+        if part.startswith("&"):
             entity = match_entity(part)
             if entity is not None:
                 converted = convert_entity(entity)
@@ -457,14 +464,14 @@ def convert_entities(text):
                 # unicode character. Otherwise, we leave the entity in.
                 if converted is not None:
                     new_text.append(converted)
-                    remainder = part[len(entity) + 2:]
+                    remainder = part[len(entity) + 2 :]
                     if part:
                         new_text.append(remainder)
                     continue
 
         new_text.append(part)
 
-    return ''.join(new_text)
+    return "".join(new_text)
 
 
 def match_entity(stream):
@@ -480,25 +487,25 @@ def match_entity(stream):
 
     """
     # Nix the & at the beginning
-    if stream[0] != '&':
+    if stream[0] != "&":
         raise ValueError('Stream should begin with "&"')
 
     stream = stream[1:]
 
     stream = list(stream)
-    possible_entity = ''
-    end_characters = '<&=;' + string.whitespace
+    possible_entity = ""
+    end_characters = "<&=;" + string.whitespace
 
     # Handle number entities
-    if stream and stream[0] == '#':
-        possible_entity = '#'
+    if stream and stream[0] == "#":
+        possible_entity = "#"
         stream.pop(0)
 
-        if stream and stream[0] in ('x', 'X'):
-            allowed = '0123456789abcdefABCDEF'
+        if stream and stream[0] in ("x", "X"):
+            allowed = "0123456789abcdefABCDEF"
             possible_entity += stream.pop(0)
         else:
-            allowed = '0123456789'
+            allowed = "0123456789"
 
         # FIXME(willkg): Do we want to make sure these are valid number
         # entities? This doesn't do that currently.
@@ -508,7 +515,7 @@ def match_entity(stream):
                 break
             possible_entity += c
 
-        if possible_entity and stream and stream[0] == ';':
+        if possible_entity and stream and stream[0] == ";":
             return possible_entity
         return None
 
@@ -519,13 +526,13 @@ def match_entity(stream):
             break
         possible_entity += c
 
-    if possible_entity and stream and stream[0] == ';':
+    if possible_entity and stream and stream[0] == ";":
         return possible_entity
 
     return None
 
 
-AMP_SPLIT_RE = re.compile('(&)')
+AMP_SPLIT_RE = re.compile("(&)")
 
 
 def next_possible_entity(text):
@@ -541,7 +548,7 @@ def next_possible_entity(text):
         if i == 0:
             yield part
         elif i % 2 == 0:
-            yield '&' + part
+            yield "&" + part
 
 
 class BleachHTMLSerializer(HTMLSerializer):
@@ -564,7 +571,7 @@ class BleachHTMLSerializer(HTMLSerializer):
         # entities and convert them to their respective characters, but the
         # BleachHTMLTokenizer doesn't do that. For example, this fixes
         # &amp;entity; back to &entity; .
-        stoken = stoken.replace('&amp;', '&')
+        stoken = stoken.replace("&amp;", "&")
 
         # However, we do want all bare & that are not marking character
         # entities to be changed to &amp;, so let's do that carefully here.
@@ -572,21 +579,21 @@ class BleachHTMLSerializer(HTMLSerializer):
             if not part:
                 continue
 
-            if part.startswith('&'):
+            if part.startswith("&"):
                 entity = match_entity(part)
                 # Only leave entities in that are not ambiguous. If they're
                 # ambiguous, then we escape the ampersand.
                 if entity is not None and convert_entity(entity) is not None:
-                    yield '&' + entity + ';'
+                    yield "&" + entity + ";"
 
                     # Length of the entity plus 2--one for & at the beginning
                     # and one for ; at the end
-                    part = part[len(entity) + 2:]
+                    part = part[len(entity) + 2 :]
                     if part:
                         yield part
                     continue
 
-            yield part.replace('&', '&amp;')
+            yield part.replace("&", "&amp;")
 
     def serialize(self, treewalker, encoding=None):
         """Wrap HTMLSerializer.serialize and conver & to &amp; in attribute values
@@ -600,7 +607,7 @@ class BleachHTMLSerializer(HTMLSerializer):
 
         for stoken in super(BleachHTMLSerializer, self).serialize(treewalker, encoding):
             if in_tag:
-                if stoken == '>':
+                if stoken == ">":
                     in_tag = False
 
                 elif after_equals:
@@ -611,11 +618,11 @@ class BleachHTMLSerializer(HTMLSerializer):
                         after_equals = False
                         continue
 
-                elif stoken == '=':
+                elif stoken == "=":
                     after_equals = True
 
                 yield stoken
             else:
-                if stoken.startswith('<'):
+                if stoken.startswith("<"):
                     in_tag = True
                 yield stoken

--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -32,14 +32,14 @@ TLDS.reverse()
 def build_url_re(tlds=TLDS, protocols=html5lib_shim.allowed_protocols):
     """Builds the url regex used by linkifier
 
-   If you want a different set of tlds or allowed protocols, pass those in
-   and stomp on the existing ``url_re``::
+    If you want a different set of tlds or allowed protocols, pass those in
+    and stomp on the existing ``url_re``::
 
-       from bleach import linkifier
+        from bleach import linkifier
 
-       my_url_re = linkifier.build_url_re(my_tlds_list, my_protocols)
+        my_url_re = linkifier.build_url_re(my_tlds_list, my_protocols)
 
-       linker = LinkifyFilter(url_re=my_url_re)
+        linker = LinkifyFilter(url_re=my_url_re)
 
     """
     return re.compile(
@@ -49,26 +49,29 @@ def build_url_re(tlds=TLDS, protocols=html5lib_shim.allowed_protocols):
         (?:[/?][^\s\{{\}}\|\\\^\[\]`<>"]*)?
             # /path/zz (excluding "unsafe" chars from RFC 1738,
             # except for # and ~, which happen in practice)
-        """.format('|'.join(sorted(protocols)), '|'.join(sorted(tlds))),
-        re.IGNORECASE | re.VERBOSE | re.UNICODE)
+        """.format(
+            "|".join(sorted(protocols)), "|".join(sorted(tlds))
+        ),
+        re.IGNORECASE | re.VERBOSE | re.UNICODE,
+    )
 
 
 URL_RE = build_url_re()
 
 
-PROTO_RE = re.compile(r'^[\w-]+:/{0,3}', re.IGNORECASE)
+PROTO_RE = re.compile(r"^[\w-]+:/{0,3}", re.IGNORECASE)
 
 
 def build_email_re(tlds=TLDS):
     """Builds the email regex used by linkifier
 
-   If you want a different set of tlds, pass those in and stomp on the existing ``email_re``::
+    If you want a different set of tlds, pass those in and stomp on the existing ``email_re``::
 
-       from bleach import linkifier
+        from bleach import linkifier
 
-       my_email_re = linkifier.build_email_re(my_tlds_list)
+        my_email_re = linkifier.build_email_re(my_tlds_list)
 
-       linker = LinkifyFilter(email_re=my_url_re)
+        linker = LinkifyFilter(email_re=my_url_re)
 
     """
     # open and closing braces doubled below for format string
@@ -79,8 +82,11 @@ def build_email_re(tlds=TLDS):
         |^"([\001-\010\013\014\016-\037!#-\[\]-\177]
             |\\[\001-\011\013\014\016-\177])*"  # quoted-string
         )@(?:[A-Z0-9](?:[A-Z0-9-]{{0,61}}[A-Z0-9])?\.)+(?:{0}))  # domain
-        """.format('|'.join(tlds)),
-        re.IGNORECASE | re.MULTILINE | re.VERBOSE)
+        """.format(
+            "|".join(tlds)
+        ),
+        re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+    )
 
 
 EMAIL_RE = build_email_re()
@@ -100,8 +106,16 @@ class Linker(object):
     situations due to crazy text.
 
     """
-    def __init__(self, callbacks=DEFAULT_CALLBACKS, skip_tags=None, parse_email=False,
-                 url_re=URL_RE, email_re=EMAIL_RE, recognized_tags=html5lib_shim.HTML_TAGS):
+
+    def __init__(
+        self,
+        callbacks=DEFAULT_CALLBACKS,
+        skip_tags=None,
+        parse_email=False,
+        url_re=URL_RE,
+        email_re=EMAIL_RE,
+        recognized_tags=html5lib_shim.HTML_TAGS,
+    ):
         """Creates a Linker instance
 
         :arg list callbacks: list of callbacks to run when adjusting tag attributes;
@@ -137,14 +151,12 @@ class Linker(object):
             consume_entities=True,
             namespaceHTMLElements=False,
         )
-        self.walker = html5lib_shim.getTreeWalker('etree')
+        self.walker = html5lib_shim.getTreeWalker("etree")
         self.serializer = html5lib_shim.BleachHTMLSerializer(
-            quote_attr_values='always',
+            quote_attr_values="always",
             omit_optional_tags=False,
-
             # linkify does not sanitize
             sanitize=False,
-
             # linkify alphabetizes
             alphabetical_attributes=False,
         )
@@ -160,12 +172,12 @@ class Linker(object):
 
         """
         if not isinstance(text, six.string_types):
-            raise TypeError('argument must be of text type')
+            raise TypeError("argument must be of text type")
 
         text = force_unicode(text)
 
         if not text:
-            return ''
+            return ""
 
         dom = self.parser.parseFragment(text)
         filtered = LinkifyFilter(
@@ -192,8 +204,16 @@ class LinkifyFilter(html5lib_shim.Filter):
     This filter can be used anywhere html5lib filters can be used.
 
     """
-    def __init__(self, source, callbacks=DEFAULT_CALLBACKS, skip_tags=None,
-                 parse_email=False, url_re=URL_RE, email_re=EMAIL_RE):
+
+    def __init__(
+        self,
+        source,
+        callbacks=DEFAULT_CALLBACKS,
+        skip_tags=None,
+        parse_email=False,
+        url_re=URL_RE,
+        email_re=EMAIL_RE,
+    ):
         """Creates a LinkifyFilter instance
 
         :arg TreeWalker source: stream
@@ -262,17 +282,17 @@ class LinkifyFilter(html5lib_shim.Filter):
 
         out = []
         for token in token_list:
-            token_type = token['type']
-            if token_type in ['Characters', 'SpaceCharacters']:
-                out.append(token['data'])
+            token_type = token["type"]
+            if token_type in ["Characters", "SpaceCharacters"]:
+                out.append(token["data"])
 
-        return ''.join(out)
+        return "".join(out)
 
     def handle_email_addresses(self, src_iter):
         """Handle email addresses in character tokens"""
         for token in src_iter:
-            if token['type'] == 'Characters':
-                text = token['data']
+            if token["type"] == "Characters":
+                text = token["data"]
                 new_tokens = []
                 end = 0
 
@@ -280,39 +300,41 @@ class LinkifyFilter(html5lib_shim.Filter):
                 for match in self.email_re.finditer(text):
                     if match.start() > end:
                         new_tokens.append(
-                            {'type': 'Characters', 'data': text[end:match.start()]}
+                            {"type": "Characters", "data": text[end : match.start()]}
                         )
 
                     # Run attributes through the callbacks to see what we
                     # should do with this match
                     attrs = {
-                        (None, 'href'): 'mailto:%s' % match.group(0),
-                        '_text': match.group(0)
+                        (None, "href"): "mailto:%s" % match.group(0),
+                        "_text": match.group(0),
                     }
                     attrs = self.apply_callbacks(attrs, True)
 
                     if attrs is None:
                         # Just add the text--but not as a link
                         new_tokens.append(
-                            {'type': 'Characters', 'data': match.group(0)}
+                            {"type": "Characters", "data": match.group(0)}
                         )
 
                     else:
                         # Add an "a" tag for the new link
-                        _text = attrs.pop('_text', '')
+                        _text = attrs.pop("_text", "")
                         attrs = alphabetize_attributes(attrs)
-                        new_tokens.extend([
-                            {'type': 'StartTag', 'name': 'a', 'data': attrs},
-                            {'type': 'Characters', 'data': force_unicode(_text)},
-                            {'type': 'EndTag', 'name': 'a'}
-                        ])
+                        new_tokens.extend(
+                            [
+                                {"type": "StartTag", "name": "a", "data": attrs},
+                                {"type": "Characters", "data": force_unicode(_text)},
+                                {"type": "EndTag", "name": "a"},
+                            ]
+                        )
                     end = match.end()
 
                 if new_tokens:
                     # Yield the adjusted set of tokens and then continue
                     # through the loop
                     if end < len(text):
-                        new_tokens.append({'type': 'Characters', 'data': text[end:]})
+                        new_tokens.append({"type": "Characters", "data": text[end:]})
 
                     for new_token in new_tokens:
                         yield new_token
@@ -327,17 +349,17 @@ class LinkifyFilter(html5lib_shim.Filter):
         This accounts for over-eager matching by the regex.
 
         """
-        prefix = suffix = ''
+        prefix = suffix = ""
 
         while fragment:
             # Try removing ( from the beginning and, if it's balanced, from the
             # end, too
-            if fragment.startswith('('):
-                prefix = prefix + '('
+            if fragment.startswith("("):
+                prefix = prefix + "("
                 fragment = fragment[1:]
 
-                if fragment.endswith(')'):
-                    suffix = ')' + suffix
+                if fragment.endswith(")"):
+                    suffix = ")" + suffix
                     fragment = fragment[:-1]
                 continue
 
@@ -347,21 +369,21 @@ class LinkifyFilter(html5lib_shim.Filter):
             #
             #     "i looked at the site (at http://example.com)"
 
-            if fragment.endswith(')') and '(' not in fragment:
+            if fragment.endswith(")") and "(" not in fragment:
                 fragment = fragment[:-1]
-                suffix = ')' + suffix
+                suffix = ")" + suffix
                 continue
 
             # Handle commas
-            if fragment.endswith(','):
+            if fragment.endswith(","):
                 fragment = fragment[:-1]
-                suffix = ',' + suffix
+                suffix = "," + suffix
                 continue
 
             # Handle periods
-            if fragment.endswith('.'):
+            if fragment.endswith("."):
                 fragment = fragment[:-1]
-                suffix = '.' + suffix
+                suffix = "." + suffix
                 continue
 
             # Nothing matched, so we're done
@@ -374,27 +396,27 @@ class LinkifyFilter(html5lib_shim.Filter):
         in_a = False  # happens, if parse_email=True and if a mail was found
         for token in src_iter:
             if in_a:
-                if token['type'] == 'EndTag' and token['name'] == 'a':
+                if token["type"] == "EndTag" and token["name"] == "a":
                     in_a = False
                 yield token
                 continue
-            elif token['type'] == 'StartTag' and token['name'] == 'a':
+            elif token["type"] == "StartTag" and token["name"] == "a":
                 in_a = True
                 yield token
                 continue
-            if token['type'] == 'Characters':
-                text = token['data']
+            if token["type"] == "Characters":
+                text = token["data"]
                 new_tokens = []
                 end = 0
 
                 for match in self.url_re.finditer(text):
                     if match.start() > end:
                         new_tokens.append(
-                            {'type': 'Characters', 'data': text[end:match.start()]}
+                            {"type": "Characters", "data": text[end : match.start()]}
                         )
 
                     url = match.group(0)
-                    prefix = suffix = ''
+                    prefix = suffix = ""
 
                     # Sometimes we pick up too much in the url match, so look for
                     # bits we should drop and remove them from the match
@@ -404,40 +426,35 @@ class LinkifyFilter(html5lib_shim.Filter):
                     if PROTO_RE.search(url):
                         href = url
                     else:
-                        href = 'http://%s' % url
+                        href = "http://%s" % url
 
-                    attrs = {
-                        (None, 'href'): href,
-                        '_text': url
-                    }
+                    attrs = {(None, "href"): href, "_text": url}
                     attrs = self.apply_callbacks(attrs, True)
 
                     if attrs is None:
                         # Just add the text
                         new_tokens.append(
-                            {'type': 'Characters', 'data': prefix + url + suffix}
+                            {"type": "Characters", "data": prefix + url + suffix}
                         )
 
                     else:
                         # Add the "a" tag!
                         if prefix:
-                            new_tokens.append(
-                                {'type': 'Characters', 'data': prefix}
-                            )
+                            new_tokens.append({"type": "Characters", "data": prefix})
 
-                        _text = attrs.pop('_text', '')
+                        _text = attrs.pop("_text", "")
                         attrs = alphabetize_attributes(attrs)
 
-                        new_tokens.extend([
-                            {'type': 'StartTag', 'name': 'a', 'data': attrs},
-                            {'type': 'Characters', 'data': force_unicode(_text)},
-                            {'type': 'EndTag', 'name': 'a'},
-                        ])
+                        new_tokens.extend(
+                            [
+                                {"type": "StartTag", "name": "a", "data": attrs},
+                                {"type": "Characters", "data": force_unicode(_text)},
+                                {"type": "EndTag", "name": "a"},
+                            ]
+                        )
 
                         if suffix:
-                            new_tokens.append(
-                                {'type': 'Characters', 'data': suffix}
-                            )
+                            new_tokens.append({"type": "Characters", "data": suffix})
 
                     end = match.end()
 
@@ -445,7 +462,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                     # Yield the adjusted set of tokens and then continue
                     # through the loop
                     if end < len(text):
-                        new_tokens.append({'type': 'Characters', 'data': text[end:]})
+                        new_tokens.append({"type": "Characters", "data": text[end:]})
 
                     for new_token in new_tokens:
                         yield new_token
@@ -464,23 +481,23 @@ class LinkifyFilter(html5lib_shim.Filter):
 
         """
         a_token = token_buffer[0]
-        if a_token['data']:
-            attrs = a_token['data']
+        if a_token["data"]:
+            attrs = a_token["data"]
         else:
             attrs = {}
         text = self.extract_character_data(token_buffer)
-        attrs['_text'] = text
+        attrs["_text"] = text
 
         attrs = self.apply_callbacks(attrs, False)
 
         if attrs is None:
             # We're dropping the "a" tag and everything else and replacing
             # it with character data. So emit that token.
-            yield {'type': 'Characters', 'data': text}
+            yield {"type": "Characters", "data": text}
 
         else:
-            new_text = attrs.pop('_text', '')
-            a_token['data'] = alphabetize_attributes(attrs)
+            new_text = attrs.pop("_text", "")
+            a_token["data"] = alphabetize_attributes(attrs)
 
             if text == new_text:
                 # The callbacks didn't change the text, so we yield the new "a"
@@ -494,7 +511,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                 # all the tokens between the start and end "a" tags and replace
                 # it with the new text
                 yield a_token
-                yield {'type': 'Characters', 'data': force_unicode(new_text)}
+                yield {"type": "Characters", "data": force_unicode(new_text)}
                 yield token_buffer[-1]
 
     def __iter__(self):
@@ -507,7 +524,7 @@ class LinkifyFilter(html5lib_shim.Filter):
             if in_a:
                 # Handle the case where we're in an "a" tag--we want to buffer tokens
                 # until we hit an end "a" tag.
-                if token['type'] == 'EndTag' and token['name'] == 'a':
+                if token["type"] == "EndTag" and token["name"] == "a":
                     # Add the end tag to the token buffer and then handle them
                     # and yield anything returned
                     token_buffer.append(token)
@@ -522,13 +539,13 @@ class LinkifyFilter(html5lib_shim.Filter):
                     token_buffer.append(token)
                 continue
 
-            if token['type'] in ['StartTag', 'EmptyTag']:
-                if token['name'] in self.skip_tags:
+            if token["type"] in ["StartTag", "EmptyTag"]:
+                if token["name"] in self.skip_tags:
                     # Skip tags start a "special mode" where we don't linkify
                     # anything until the end tag.
-                    in_skip_tag = token['name']
+                    in_skip_tag = token["name"]
 
-                elif token['name'] == 'a':
+                elif token["name"] == "a":
                     # The "a" tag is special--we switch to a slurp mode and
                     # slurp all the tokens until the end "a" tag and then
                     # figure out what to do with them there.
@@ -542,10 +559,10 @@ class LinkifyFilter(html5lib_shim.Filter):
             elif in_skip_tag and self.skip_tags:
                 # NOTE(willkg): We put this clause here since in_a and
                 # switching in and out of in_a takes precedence.
-                if token['type'] == 'EndTag' and token['name'] == in_skip_tag:
+                if token["type"] == "EndTag" and token["name"] == in_skip_tag:
                     in_skip_tag = None
 
-            elif not in_a and not in_skip_tag and token['type'] == 'Characters':
+            elif not in_a and not in_skip_tag and token["type"] == "Characters":
                 new_stream = iter([token])
                 if self.parse_email:
                     new_stream = self.handle_email_addresses(new_stream)

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -18,46 +18,45 @@ warnings.simplefilter("ignore", category=DeprecationWarning)
 
 #: List of allowed tags
 ALLOWED_TAGS = [
-    'a',
-    'abbr',
-    'acronym',
-    'b',
-    'blockquote',
-    'code',
-    'em',
-    'i',
-    'li',
-    'ol',
-    'strong',
-    'ul',
+    "a",
+    "abbr",
+    "acronym",
+    "b",
+    "blockquote",
+    "code",
+    "em",
+    "i",
+    "li",
+    "ol",
+    "strong",
+    "ul",
 ]
 
 
 #: Map of allowed attributes by tag
 ALLOWED_ATTRIBUTES = {
-    'a': ['href', 'title'],
-    'abbr': ['title'],
-    'acronym': ['title'],
+    "a": ["href", "title"],
+    "abbr": ["title"],
+    "acronym": ["title"],
 }
 
 #: List of allowed styles
 ALLOWED_STYLES = []
 
 #: List of allowed protocols
-ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']
+ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
 
 #: Invisible characters--0 to and including 31 except 9 (tab), 10 (lf), and 13 (cr)
-INVISIBLE_CHARACTERS = ''.join([chr(c) for c in chain(range(0, 9), range(11, 13), range(14, 32))])
+INVISIBLE_CHARACTERS = "".join(
+    [chr(c) for c in chain(range(0, 9), range(11, 13), range(14, 32))]
+)
 
 #: Regexp for characters that are invisible
-INVISIBLE_CHARACTERS_RE = re.compile(
-    '[' + INVISIBLE_CHARACTERS + ']',
-    re.UNICODE
-)
+INVISIBLE_CHARACTERS_RE = re.compile("[" + INVISIBLE_CHARACTERS + "]", re.UNICODE)
 
 #: String to replace invisible characters with. This can be a character, a
 #: string, or even a function that takes a Python re matchobj
-INVISIBLE_REPLACEMENT_CHAR = '?'
+INVISIBLE_REPLACEMENT_CHAR = "?"
 
 
 class Cleaner(object):
@@ -89,9 +88,16 @@ class Cleaner(object):
 
     """
 
-    def __init__(self, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-                 styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False,
-                 strip_comments=True, filters=None):
+    def __init__(
+        self,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        styles=ALLOWED_STYLES,
+        protocols=ALLOWED_PROTOCOLS,
+        strip=False,
+        strip_comments=True,
+        filters=None,
+    ):
         """Initializes a Cleaner
 
         :arg list tags: allowed list of tags; defaults to
@@ -132,21 +138,18 @@ class Cleaner(object):
             tags=self.tags,
             strip=self.strip,
             consume_entities=False,
-            namespaceHTMLElements=False
+            namespaceHTMLElements=False,
         )
-        self.walker = html5lib_shim.getTreeWalker('etree')
+        self.walker = html5lib_shim.getTreeWalker("etree")
         self.serializer = html5lib_shim.BleachHTMLSerializer(
-            quote_attr_values='always',
+            quote_attr_values="always",
             omit_optional_tags=False,
             escape_lt_in_attrs=True,
-
             # We want to leave entities as they are without escaping or
             # resolving or expanding
             resolve_entities=False,
-
             # Bleach has its own sanitizer, so don't use the html5lib one
             sanitize=False,
-
             # Bleach sanitizer alphabetizes already, so don't use the html5lib one
             alphabetical_attributes=False,
         )
@@ -162,24 +165,25 @@ class Cleaner(object):
 
         """
         if not isinstance(text, six.string_types):
-            message = "argument cannot be of '{name}' type, must be of text type".format(
-                name=text.__class__.__name__)
+            message = (
+                "argument cannot be of '{name}' type, must be of text type".format(
+                    name=text.__class__.__name__
+                )
+            )
             raise TypeError(message)
 
         if not text:
-            return ''
+            return ""
 
         text = force_unicode(text)
 
         dom = self.parser.parseFragment(text)
         filtered = BleachSanitizerFilter(
             source=self.walker(dom),
-
             # Bleach-sanitizer-specific things
             attributes=self.attributes,
             strip_disallowed_elements=self.strip,
             strip_html_comments=self.strip_comments,
-
             # html5lib-sanitizer things
             allowed_elements=self.tags,
             allowed_css_properties=self.styles,
@@ -206,6 +210,7 @@ def attribute_filter_factory(attributes):
         return attributes
 
     if isinstance(attributes, dict):
+
         def _attr_filter(tag, attr, value):
             if tag in attributes:
                 attr_val = attributes[tag]
@@ -215,8 +220,8 @@ def attribute_filter_factory(attributes):
                 if attr in attr_val:
                     return True
 
-            if '*' in attributes:
-                attr_val = attributes['*']
+            if "*" in attributes:
+                attr_val = attributes["*"]
                 if callable(attr_val):
                     return attr_val(tag, attr, value)
 
@@ -227,12 +232,13 @@ def attribute_filter_factory(attributes):
         return _attr_filter
 
     if isinstance(attributes, list):
+
         def _attr_filter(tag, attr, value):
             return attr in attributes
 
         return _attr_filter
 
-    raise ValueError('attributes needs to be a callable, a list or a dict')
+    raise ValueError("attributes needs to be a callable, a list or a dict")
 
 
 class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
@@ -241,9 +247,15 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
     This filter can be used anywhere html5lib filters can be used.
 
     """
-    def __init__(self, source, attributes=ALLOWED_ATTRIBUTES,
-                 strip_disallowed_elements=False, strip_html_comments=True,
-                 **kwargs):
+
+    def __init__(
+        self,
+        source,
+        attributes=ALLOWED_ATTRIBUTES,
+        strip_disallowed_elements=False,
+        strip_html_comments=True,
+        **kwargs
+    ):
         """Creates a BleachSanitizerFilter instance
 
         :arg Treewalker source: stream
@@ -291,33 +303,37 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
 
         for token in token_iterator:
             if characters_buffer:
-                if token['type'] == 'Characters':
+                if token["type"] == "Characters":
                     characters_buffer.append(token)
                     continue
                 else:
                     # Merge all the characters tokens together into one and then
                     # operate on it.
                     new_token = {
-                        'data': ''.join([char_token['data'] for char_token in characters_buffer]),
-                        'type': 'Characters'
+                        "data": "".join(
+                            [char_token["data"] for char_token in characters_buffer]
+                        ),
+                        "type": "Characters",
                     }
                     characters_buffer = []
                     yield new_token
 
-            elif token['type'] == 'Characters':
+            elif token["type"] == "Characters":
                 characters_buffer.append(token)
                 continue
 
             yield token
 
         new_token = {
-            'data': ''.join([char_token['data'] for char_token in characters_buffer]),
-            'type': 'Characters'
+            "data": "".join([char_token["data"] for char_token in characters_buffer]),
+            "type": "Characters",
         }
         yield new_token
 
     def __iter__(self):
-        return self.merge_characters(self.sanitize_stream(html5lib_shim.Filter.__iter__(self)))
+        return self.merge_characters(
+            self.sanitize_stream(html5lib_shim.Filter.__iter__(self))
+        )
 
     def sanitize_token(self, token):
         """Sanitize a token either by HTML-encoding or dropping.
@@ -335,28 +351,28 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
         :returns: token or list of tokens
 
         """
-        token_type = token['type']
-        if token_type in ['StartTag', 'EndTag', 'EmptyTag']:
-            if token['name'] in self.allowed_elements:
+        token_type = token["type"]
+        if token_type in ["StartTag", "EndTag", "EmptyTag"]:
+            if token["name"] in self.allowed_elements:
                 return self.allow_token(token)
 
             elif self.strip_disallowed_elements:
                 return None
 
             else:
-                if 'data' in token:
+                if "data" in token:
                     # Alphabetize the attributes before calling .disallowed_token()
                     # so that the resulting string is stable
-                    token['data'] = alphabetize_attributes(token['data'])
+                    token["data"] = alphabetize_attributes(token["data"])
                 return self.disallowed_token(token)
 
-        elif token_type == 'Comment':
+        elif token_type == "Comment":
             if not self.strip_html_comments:
                 return token
             else:
                 return None
 
-        elif token_type == 'Characters':
+        elif token_type == "Characters":
             return self.sanitize_characters(token)
 
         else:
@@ -377,16 +393,16 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
         :returns: a list of tokens
 
         """
-        data = token.get('data', '')
+        data = token.get("data", "")
 
         if not data:
             return token
 
         data = INVISIBLE_CHARACTERS_RE.sub(INVISIBLE_REPLACEMENT_CHAR, data)
-        token['data'] = data
+        token["data"] = data
 
         # If there isn't a & in the data, we can return now
-        if '&' not in data:
+        if "&" not in data:
             return token
 
         new_tokens = []
@@ -397,10 +413,10 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
             if not part:
                 continue
 
-            if part.startswith('&'):
+            if part.startswith("&"):
                 entity = html5lib_shim.match_entity(part)
                 if entity is not None:
-                    if entity == 'amp':
+                    if entity == "amp":
                         # LinkifyFilter can't match urls across token boundaries
                         # which is problematic with &amp; since that shows up in
                         # querystrings all the time. This special-cases &amp;
@@ -408,18 +424,18 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
                         # Characters token. It'll get merged with surrounding
                         # tokens in the BleachSanitizerfilter.__iter__ and
                         # escaped in the serializer.
-                        new_tokens.append({'type': 'Characters', 'data': '&'})
+                        new_tokens.append({"type": "Characters", "data": "&"})
                     else:
-                        new_tokens.append({'type': 'Entity', 'name': entity})
+                        new_tokens.append({"type": "Entity", "name": entity})
 
                     # Length of the entity plus 2--one for & at the beginning
                     # and one for ; at the end
-                    remainder = part[len(entity) + 2:]
+                    remainder = part[len(entity) + 2 :]
                     if remainder:
-                        new_tokens.append({'type': 'Characters', 'data': remainder})
+                        new_tokens.append({"type": "Characters", "data": remainder})
                     continue
 
-            new_tokens.append({'type': 'Characters', 'data': part})
+            new_tokens.append({"type": "Characters", "data": part})
 
         return new_tokens
 
@@ -440,14 +456,10 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
         new_value = html5lib_shim.convert_entities(value)
 
         # Nix backtick, space characters, and control characters
-        new_value = re.sub(
-            r"[`\000-\040\177-\240\s]+",
-            '',
-            new_value
-        )
+        new_value = re.sub(r"[`\000-\040\177-\240\s]+", "", new_value)
 
         # Remove REPLACEMENT characters
-        new_value = new_value.replace('\ufffd', '')
+        new_value = new_value.replace("\ufffd", "")
 
         # Lowercase it--this breaks the value, but makes it easier to match
         # against
@@ -468,23 +480,23 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
 
         else:
             # Allow uris that are just an anchor
-            if new_value.startswith('#'):
+            if new_value.startswith("#"):
                 return value
 
             # Handle protocols that urlparse doesn't recognize like "myprotocol"
-            if ':' in new_value and new_value.split(':')[0] in allowed_protocols:
+            if ":" in new_value and new_value.split(":")[0] in allowed_protocols:
                 return value
 
             # If there's no protocol/scheme specified, then assume it's "http"
             # and see if that's allowed
-            if 'http' in allowed_protocols:
+            if "http" in allowed_protocols:
                 return value
 
         return None
 
     def allow_token(self, token):
         """Handles the case where we're allowing the tag"""
-        if 'data' in token:
+        if "data" in token:
             # Loop through all the attributes and drop the ones that are not
             # allowed, are unsafe or break other rules. Additionally, fix
             # attribute values that need fixing.
@@ -492,14 +504,14 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
             # At the end of this loop, we have the final set of attributes
             # we're keeping.
             attrs = {}
-            for namespaced_name, val in token['data'].items():
+            for namespaced_name, val in token["data"].items():
                 namespace, name = namespaced_name
 
                 # Drop attributes that are not explicitly allowed
                 #
                 # NOTE(willkg): We pass in the attribute name--not a namespaced
                 # name.
-                if not self.attr_filter(token['name'], name, val):
+                if not self.attr_filter(token["name"], name, val):
                     continue
 
                 # Drop attributes with uri values that use a disallowed protocol
@@ -512,9 +524,7 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
 
                 # Drop values in svg attrs with non-local IRIs
                 if namespaced_name in self.svg_attr_val_allows_ref:
-                    new_val = re.sub(r'url\s*\(\s*[^#\s][^)]+?\)',
-                                     ' ',
-                                     unescape(val))
+                    new_val = re.sub(r"url\s*\(\s*[^#\s][^)]+?\)", " ", unescape(val))
                     new_val = new_val.strip()
                     if not new_val:
                         continue
@@ -525,21 +535,22 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
                         val = new_val
 
                 # Drop href and xlink:href attr for svg elements with non-local IRIs
-                if (None, token['name']) in self.svg_allow_local_href:
+                if (None, token["name"]) in self.svg_allow_local_href:
                     if namespaced_name in [
-                            (None, 'href'), (html5lib_shim.namespaces['xlink'], 'href')
+                        (None, "href"),
+                        (html5lib_shim.namespaces["xlink"], "href"),
                     ]:
-                        if re.search(r'^\s*[^#\s]', val):
+                        if re.search(r"^\s*[^#\s]", val):
                             continue
 
                 # If it's a style attribute, sanitize it
-                if namespaced_name == (None, 'style'):
+                if namespaced_name == (None, "style"):
                     val = self.sanitize_css(val)
 
                 # At this point, we want to keep the attribute, so add it in
                 attrs[namespaced_name] = val
 
-            token['data'] = alphabetize_attributes(attrs)
+            token["data"] = alphabetize_attributes(attrs)
 
         return token
 
@@ -562,16 +573,19 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
                 if ns is None or ns not in html5lib_shim.prefixes:
                     namespaced_name = name
                 else:
-                    namespaced_name = '%s:%s' % (html5lib_shim.prefixes[ns], name)
+                    namespaced_name = "%s:%s" % (html5lib_shim.prefixes[ns], name)
 
-                attrs.append(' %s="%s"' % (
-                    namespaced_name,
-                    # NOTE(willkg): HTMLSerializer escapes attribute values
-                    # already, so if we do it here (like HTMLSerializer does),
-                    # then we end up double-escaping.
-                    v)
+                attrs.append(
+                    ' %s="%s"'
+                    % (
+                        namespaced_name,
+                        # NOTE(willkg): HTMLSerializer escapes attribute values
+                        # already, so if we do it here (like HTMLSerializer does),
+                        # then we end up double-escaping.
+                        v,
+                    )
                 )
-            token["data"] = "<%s%s>" % (token["name"], ''.join(attrs))
+            token["data"] = "<%s%s>" % (token["name"], "".join(attrs))
 
         else:
             token["data"] = "<%s>" % token["name"]
@@ -590,13 +604,13 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
         style = html5lib_shim.convert_entities(style)
 
         # Drop any url values before we do anything else
-        style = re.compile(r'url\s*\(\s*[^\s)]+?\s*\)\s*').sub(' ', style)
+        style = re.compile(r"url\s*\(\s*[^\s)]+?\s*\)\s*").sub(" ", style)
 
         # The gauntlet of sanitization
 
         # Validate the css in the style tag and if it's not valid, then drop
         # the whole thing.
-        parts = style.split(';')
+        parts = style.split(";")
         gauntlet = re.compile(
             r"""^(  # consider a style attribute value as composed of:
 [/:,#%!.\s\w]    # a non-newline character
@@ -605,25 +619,25 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
 |"[\s\w]+"       # a double quoted string of [\s\w]+
 |\([\d,%\.\s]+\) # a parenthesized string of one or more digits, commas, periods, ...
 )*$""",  # ... percent signs, or whitespace e.g. from 'color: hsl(30,100%,50%)'
-            flags=re.U | re.VERBOSE
+            flags=re.U | re.VERBOSE,
         )
 
         for part in parts:
             if not gauntlet.match(part):
-                return ''
+                return ""
 
         if not re.match(r"^\s*([-\w]+\s*:[^:;]*(;\s*|$))*$", style):
-            return ''
+            return ""
 
         clean = []
-        for prop, value in re.findall(r'([-\w]+)\s*:\s*([^:;]*)', style):
+        for prop, value in re.findall(r"([-\w]+)\s*:\s*([^:;]*)", style):
             if not value:
                 continue
 
             if prop.lower() in self.allowed_css_properties:
-                clean.append(prop + ': ' + value + ';')
+                clean.append(prop + ": " + value + ";")
 
             elif prop.lower() in self.allowed_svg_properties:
-                clean.append(prop + ': ' + value + ';')
+                clean.append(prop + ": " + value + ";")
 
-        return ' '.join(clean)
+        return " ".join(clean)

--- a/bleach/utils.py
+++ b/bleach/utils.py
@@ -11,7 +11,7 @@ def _attr_key(attr):
     ``None`` to an empty string.
 
     """
-    key = (attr[0][0] or ''), attr[0][1]
+    key = (attr[0][0] or ""), attr[0][1]
     return key
 
 
@@ -20,9 +20,7 @@ def alphabetize_attributes(attrs):
     if not attrs:
         return attrs
 
-    return OrderedDict(
-        [(k, v) for k, v in sorted(attrs.items(), key=_attr_key)]
-    )
+    return OrderedDict([(k, v) for k, v in sorted(attrs.items(), key=_attr_key)])
 
 
 def force_unicode(text):
@@ -41,4 +39,4 @@ def force_unicode(text):
         return text
 
     # If not, convert it
-    return six.text_type(text, 'utf-8', 'strict')
+    return six.text_type(text, "utf-8", "strict")

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -18,6 +18,10 @@ case "${MODE}" in
     ./scripts/vendor_verify.sh ;;
   docs)
     tox -e docs ;;
+  format)
+    black bleach/*.py tests/ tests_website/ ;;
+  format-check)
+    black --check --diff bleach/*.py tests/ tests_website/ ;;
   *)
     echo "Unknown mode $MODE."
     exit 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ exclude =
 ignore =
     # E731: do not assign a lambda expression, use a def
     E731,
+    # E203: whitespace before : (refs: https://github.com/PyCQA/pycodestyle/issues/373)
+    E203,
     # W503: line break occurred before a binary operator
     W503
 max-line-length = 100

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -9,36 +9,36 @@ class TestNofollowCallback:
         assert nofollow(attrs) == attrs
 
     def test_no_href(self):
-        attrs = {'_text': 'something something'}
+        attrs = {"_text": "something something"}
         assert nofollow(attrs) == attrs
 
     def test_basic(self):
-        attrs = {(None, 'href'): 'http://example.com'}
-        assert (
-            nofollow(attrs) ==
-            {(None, 'href'): 'http://example.com', (None, 'rel'): 'nofollow'}
-        )
+        attrs = {(None, "href"): "http://example.com"}
+        assert nofollow(attrs) == {
+            (None, "href"): "http://example.com",
+            (None, "rel"): "nofollow",
+        }
 
     def test_mailto(self):
-        attrs = {(None, 'href'): 'mailto:joe@example.com'}
+        attrs = {(None, "href"): "mailto:joe@example.com"}
         assert nofollow(attrs) == attrs
 
     def test_has_nofollow_already(self):
         attrs = {
-            (None, 'href'): 'http://example.com',
-            (None, 'rel'): 'nofollow',
+            (None, "href"): "http://example.com",
+            (None, "rel"): "nofollow",
         }
         assert nofollow(attrs) == attrs
 
     def test_other_rel(self):
         attrs = {
-            (None, 'href'): 'http://example.com',
-            (None, 'rel'): 'next',
+            (None, "href"): "http://example.com",
+            (None, "rel"): "next",
         }
-        assert (
-            nofollow(attrs) ==
-            {(None, 'href'): 'http://example.com', (None, 'rel'): 'next nofollow'}
-        )
+        assert nofollow(attrs) == {
+            (None, "href"): "http://example.com",
+            (None, "rel"): "next nofollow",
+        }
 
 
 class TestTargetBlankCallback:
@@ -47,19 +47,19 @@ class TestTargetBlankCallback:
         assert target_blank(attrs) == attrs
 
     def test_mailto(self):
-        attrs = {(None, 'href'): 'mailto:joe@example.com'}
+        attrs = {(None, "href"): "mailto:joe@example.com"}
         assert target_blank(attrs) == attrs
 
     def test_add_target(self):
-        attrs = {(None, 'href'): 'http://example.com'}
-        assert (
-            target_blank(attrs) ==
-            {(None, 'href'): 'http://example.com', (None, 'target'): '_blank'}
-        )
+        attrs = {(None, "href"): "http://example.com"}
+        assert target_blank(attrs) == {
+            (None, "href"): "http://example.com",
+            (None, "target"): "_blank",
+        }
 
     def test_stomp_target(self):
-        attrs = {(None, 'href'): 'http://example.com', (None, 'target'): 'foo'}
-        assert (
-            target_blank(attrs) ==
-            {(None, 'href'): 'http://example.com', (None, 'target'): '_blank'}
-        )
+        attrs = {(None, "href"): "http://example.com", (None, "target"): "foo"}
+        assert target_blank(attrs) == {
+            (None, "href"): "http://example.com",
+            (None, "target"): "_blank",
+        }

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -9,14 +9,15 @@ from bleach.html5lib_shim import Filter
 from bleach.sanitizer import Cleaner
 from bleach._vendor.html5lib.constants import rcdataElements
 
+
 def test_clean_idempotent():
     """Make sure that applying the filter twice doesn't change anything."""
-    dirty = '<span>invalid & </span> < extra http://link.com<em>'
+    dirty = "<span>invalid & </span> < extra http://link.com<em>"
     assert clean(clean(dirty)) == clean(dirty)
 
 
 def test_only_text_is_cleaned():
-    some_text = 'text'
+    some_text = "text"
     some_type = int
     no_type = None
 
@@ -32,350 +33,272 @@ def test_only_text_is_cleaned():
 
 
 def test_empty():
-    assert clean('') == ''
+    assert clean("") == ""
 
 
 def test_content_has_no_html():
-    assert clean('no html string') == 'no html string'
+    assert clean("no html string") == "no html string"
 
 
-@pytest.mark.parametrize('data, expected', [
-    (
-        'an <strong>allowed</strong> tag',
-        'an <strong>allowed</strong> tag'
-    ),
-
-    (
-        'another <em>good</em> tag',
-        'another <em>good</em> tag'
-    )
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        ("an <strong>allowed</strong> tag", "an <strong>allowed</strong> tag"),
+        ("another <em>good</em> tag", "another <em>good</em> tag"),
+    ],
+)
 def test_content_has_allowed_html(data, expected):
     assert clean(data) == expected
 
 
 def test_html_is_lowercased():
     assert (
-        clean('<A HREF="http://example.com">foo</A>') ==
-        '<a href="http://example.com">foo</a>'
+        clean('<A HREF="http://example.com">foo</A>')
+        == '<a href="http://example.com">foo</a>'
     )
 
 
 def test_invalid_uri_does_not_raise_error():
-    assert clean('<a href="http://example.com]">text</a>') == '<a>text</a>'
+    assert clean('<a href="http://example.com]">text</a>') == "<a>text</a>"
 
 
-@pytest.mark.parametrize('data, should_strip, expected', [
-    # Regular comment
-    (
-        '<!-- this is a comment -->',
-        True,
-        ''
-    ),
-
-    # Open comment with no close comment bit
-    (
-        '<!-- open comment',
-        True,
-        ''
-    ),
-    (
-        '<!--open comment',
-        True,
-        ''
-    ),
-    (
-        '<!-- open comment',
-        False,
-        '<!-- open comment-->'
-    ),
-    (
-        '<!--open comment',
-        False,
-        '<!--open comment-->'
-    ),
-
-    # Comment with text to the right
-    (
-        '<!-- comment -->text',
-        True,
-        'text'
-    ),
-    (
-        '<!--comment-->text',
-        True,
-        'text'
-    ),
-    (
-        '<!-- comment -->text',
-        False,
-        '<!-- comment -->text'
-    ),
-    (
-        '<!--comment-->text',
-        False,
-        '<!--comment-->text'
-    ),
-
-    # Comment with text to the left
-    (
-        'text<!-- comment -->',
-        True,
-        'text'
-    ),
-    (
-        'text<!--comment-->',
-        True,
-        'text'
-    ),
-    (
-        'text<!-- comment -->',
-        False,
-        'text<!-- comment -->'
-    ),
-    (
-        'text<!--comment-->',
-        False,
-        'text<!--comment-->'
-    )
-])
+@pytest.mark.parametrize(
+    "data, should_strip, expected",
+    [
+        # Regular comment
+        ("<!-- this is a comment -->", True, ""),
+        # Open comment with no close comment bit
+        ("<!-- open comment", True, ""),
+        ("<!--open comment", True, ""),
+        ("<!-- open comment", False, "<!-- open comment-->"),
+        ("<!--open comment", False, "<!--open comment-->"),
+        # Comment with text to the right
+        ("<!-- comment -->text", True, "text"),
+        ("<!--comment-->text", True, "text"),
+        ("<!-- comment -->text", False, "<!-- comment -->text"),
+        ("<!--comment-->text", False, "<!--comment-->text"),
+        # Comment with text to the left
+        ("text<!-- comment -->", True, "text"),
+        ("text<!--comment-->", True, "text"),
+        ("text<!-- comment -->", False, "text<!-- comment -->"),
+        ("text<!--comment-->", False, "text<!--comment-->"),
+    ],
+)
 def test_comments(data, should_strip, expected):
     assert clean(data, strip_comments=should_strip) == expected
 
 
 def test_invalid_char_in_tag():
     assert (
-        clean('<script/xss src="http://xx.com/xss.js"></script>') ==
-        '&lt;script/xss src="http://xx.com/xss.js"&gt;&lt;/script&gt;'
+        clean('<script/xss src="http://xx.com/xss.js"></script>')
+        == '&lt;script/xss src="http://xx.com/xss.js"&gt;&lt;/script&gt;'
     )
     assert (
-        clean('<script/src="http://xx.com/xss.js"></script>') ==
-        '&lt;script/src="http://xx.com/xss.js"&gt;&lt;/script&gt;'
+        clean('<script/src="http://xx.com/xss.js"></script>')
+        == '&lt;script/src="http://xx.com/xss.js"&gt;&lt;/script&gt;'
     )
 
 
 def test_unclosed_tag():
+    assert clean("a <em>fixed tag") == "a <em>fixed tag</em>"
     assert (
-        clean('a <em>fixed tag') ==
-        'a <em>fixed tag</em>'
+        clean("<script src=http://xx.com/xss.js<b>")
+        == "&lt;script src=http://xx.com/xss.js&lt;b&gt;"
     )
     assert (
-        clean('<script src=http://xx.com/xss.js<b>') ==
-        '&lt;script src=http://xx.com/xss.js&lt;b&gt;'
+        clean('<script src="http://xx.com/xss.js"<b>')
+        == '&lt;script src="http://xx.com/xss.js"&lt;b&gt;'
     )
     assert (
-        clean('<script src="http://xx.com/xss.js"<b>') ==
-        '&lt;script src="http://xx.com/xss.js"&lt;b&gt;'
-    )
-    assert (
-        clean('<script src="http://xx.com/xss.js" <b>') ==
-        '&lt;script src="http://xx.com/xss.js" &lt;b&gt;'
+        clean('<script src="http://xx.com/xss.js" <b>')
+        == '&lt;script src="http://xx.com/xss.js" &lt;b&gt;'
     )
 
 
 def test_nested_script_tag():
     assert (
-        clean('<<script>script>evil()<</script>/script>') ==
-        '&lt;&lt;script&gt;script&gt;evil()&lt;&lt;/script&gt;/script&gt;'
+        clean("<<script>script>evil()<</script>/script>")
+        == "&lt;&lt;script&gt;script&gt;evil()&lt;&lt;/script&gt;/script&gt;"
     )
     assert (
-        clean('<<x>script>evil()<</x>/script>') ==
-        '&lt;&lt;x&gt;script&gt;evil()&lt;&lt;/x&gt;/script&gt;'
+        clean("<<x>script>evil()<</x>/script>")
+        == "&lt;&lt;x&gt;script&gt;evil()&lt;&lt;/x&gt;/script&gt;"
     )
     assert (
-        clean('<script<script>>evil()</script</script>>') ==
-        '&lt;script&lt;script&gt;&gt;evil()&lt;/script&lt;/script&gt;&gt;'
+        clean("<script<script>>evil()</script</script>>")
+        == "&lt;script&lt;script&gt;&gt;evil()&lt;/script&lt;/script&gt;&gt;"
     )
 
 
-@pytest.mark.parametrize('text, expected', [
-    ('an & entity', 'an &amp; entity'),
-    ('an < entity', 'an &lt; entity'),
-    ('tag < <em>and</em> entity', 'tag &lt; <em>and</em> entity'),
-])
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("an & entity", "an &amp; entity"),
+        ("an < entity", "an &lt; entity"),
+        ("tag < <em>and</em> entity", "tag &lt; <em>and</em> entity"),
+    ],
+)
 def test_bare_entities_get_escaped_correctly(text, expected):
     assert clean(text) == expected
 
 
-@pytest.mark.parametrize('text, expected', [
-    # Test character entities
-    ('&amp;', '&amp;'),
-    ('&nbsp;', '&nbsp;'),
-    ('&nbsp; test string &nbsp;', '&nbsp; test string &nbsp;'),
-    ('&lt;em&gt;strong&lt;/em&gt;', '&lt;em&gt;strong&lt;/em&gt;'),
-
-    # Test character entity at beginning of string
-    ('&amp;is cool', '&amp;is cool'),
-
-    # Test it at the end of the string
-    ('cool &amp;', 'cool &amp;'),
-
-    # Test bare ampersands and entities at beginning
-    ('&&amp; is cool', '&amp;&amp; is cool'),
-
-    # Test entities and bare ampersand at end
-    ('&amp; is cool &amp;&', '&amp; is cool &amp;&amp;'),
-
-    # Test missing semi-colon means we don't treat it like an entity
-    ('this &amp that', 'this &amp;amp that'),
-
-    # Test a thing that looks like a character entity, but isn't because it's
-    # missing a ; (&current)
-    (
-        'http://example.com?active=true&current=true',
-        'http://example.com?active=true&amp;current=true'
-    ),
-
-    # Test character entities in attribute values are left alone
-    (
-        '<a href="?art&amp;copy">foo</a>',
-        '<a href="?art&amp;copy">foo</a>'
-    ),
-    (
-        '<a href="?this=&gt;that">foo</a>',
-        '<a href="?this=&gt;that">foo</a>'
-    ),
-
-    # Ambiguous ampersands get escaped in attributes
-    (
-        '<a href="http://example.com/&xx;">foo</a>',
-        '<a href="http://example.com/&amp;xx;">foo</a>'
-    ),
-    (
-        '<a href="http://example.com?active=true&current=true">foo</a>',
-        '<a href="http://example.com?active=true&amp;current=true">foo</a>'
-    ),
-
-    # Ambiguous ampersands in text are not escaped
-    ('&xx;', '&xx;'),
-
-    # Test numeric entities
-    ('&#39;', '&#39;'),
-    ('&#34;', '&#34;'),
-    ('&#123;', '&#123;'),
-    ('&#x0007b;', '&#x0007b;'),
-    ('&#x0007B;', '&#x0007B;'),
-
-    # Test non-numeric entities
-    ('&#', '&amp;#'),
-    ('&#<', '&amp;#&lt;'),
-
-    # html5lib tokenizer unescapes character entities, so these would become '
-    # and " which makes it possible to break out of html attributes.
-    #
-    # Verify that clean() doesn't unescape entities.
-    ('&#39;&#34;', '&#39;&#34;'),
-])
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # Test character entities
+        ("&amp;", "&amp;"),
+        ("&nbsp;", "&nbsp;"),
+        ("&nbsp; test string &nbsp;", "&nbsp; test string &nbsp;"),
+        ("&lt;em&gt;strong&lt;/em&gt;", "&lt;em&gt;strong&lt;/em&gt;"),
+        # Test character entity at beginning of string
+        ("&amp;is cool", "&amp;is cool"),
+        # Test it at the end of the string
+        ("cool &amp;", "cool &amp;"),
+        # Test bare ampersands and entities at beginning
+        ("&&amp; is cool", "&amp;&amp; is cool"),
+        # Test entities and bare ampersand at end
+        ("&amp; is cool &amp;&", "&amp; is cool &amp;&amp;"),
+        # Test missing semi-colon means we don't treat it like an entity
+        ("this &amp that", "this &amp;amp that"),
+        # Test a thing that looks like a character entity, but isn't because it's
+        # missing a ; (&current)
+        (
+            "http://example.com?active=true&current=true",
+            "http://example.com?active=true&amp;current=true",
+        ),
+        # Test character entities in attribute values are left alone
+        ('<a href="?art&amp;copy">foo</a>', '<a href="?art&amp;copy">foo</a>'),
+        ('<a href="?this=&gt;that">foo</a>', '<a href="?this=&gt;that">foo</a>'),
+        # Ambiguous ampersands get escaped in attributes
+        (
+            '<a href="http://example.com/&xx;">foo</a>',
+            '<a href="http://example.com/&amp;xx;">foo</a>',
+        ),
+        (
+            '<a href="http://example.com?active=true&current=true">foo</a>',
+            '<a href="http://example.com?active=true&amp;current=true">foo</a>',
+        ),
+        # Ambiguous ampersands in text are not escaped
+        ("&xx;", "&xx;"),
+        # Test numeric entities
+        ("&#39;", "&#39;"),
+        ("&#34;", "&#34;"),
+        ("&#123;", "&#123;"),
+        ("&#x0007b;", "&#x0007b;"),
+        ("&#x0007B;", "&#x0007B;"),
+        # Test non-numeric entities
+        ("&#", "&amp;#"),
+        ("&#<", "&amp;#&lt;"),
+        # html5lib tokenizer unescapes character entities, so these would become '
+        # and " which makes it possible to break out of html attributes.
+        #
+        # Verify that clean() doesn't unescape entities.
+        ("&#39;&#34;", "&#39;&#34;"),
+    ],
+)
 def test_character_entities_handling(text, expected):
     assert clean(text) == expected
 
 
-@pytest.mark.parametrize('data, kwargs, expected', [
-    # All tags are allowed, so it strips nothing
-    (
-        'a test <em>with</em> <b>html</b> tags',
-        {},
-        'a test <em>with</em> <b>html</b> tags'
-    ),
-
-    # img tag is disallowed, so it's stripped
-    (
-        'a test <em>with</em> <img src="http://example.com/"> <b>html</b> tags',
-        {},
-        'a test <em>with</em>  <b>html</b> tags'
-    ),
-
-    # a tag is disallowed, so it's stripped
-    (
-        '<p><a href="http://example.com/">link text</a></p>',
-        {'tags': ['p']},
-        '<p>link text</p>'
-    ),
-
-    # Test nested disallowed tag
-    (
-        '<p><span>multiply <span>nested <span>text</span></span></span></p>',
-        {'tags': ['p']},
-        '<p>multiply nested text</p>'
-    ),
-    # (#271)
-    (
-        '<ul><li><script></li></ul>',
-        {'tags': ['ul', 'li']},
-        '<ul><li></li></ul>'
-    ),
-
-    # Test disallowed tag that's deep in the tree
-    (
-        '<p><a href="http://example.com/"><img src="http://example.com/"></a></p>',
-        {'tags': ['a', 'p']},
-        '<p><a href="http://example.com/"></a></p>'
-    ),
-
-    # Test isindex -- the parser expands this to a prompt (#279)
-    ('<isindex>', {}, ''),
-
-    # Test non-tags that are well-formed HTML (#280)
-    ('Yeah right <sarcasm/>', {}, 'Yeah right '),
-    ('<sarcasm>', {}, ''),
-    ('</sarcasm>', {}, ''),
-
-    # These are non-tags, but also "malformed" so they don't get treated like
-    # tags and stripped
-    ('</ sarcasm>', {}, '&lt;/ sarcasm&gt;'),
-    ('</ sarcasm >', {}, '&lt;/ sarcasm &gt;'),
-    ('Foo <bar@example.com>', {}, 'Foo '),
-    ('Favorite movie: <name of movie>', {}, 'Favorite movie: '),
-    ('</3', {}, '&lt;/3'),
-])
+@pytest.mark.parametrize(
+    "data, kwargs, expected",
+    [
+        # All tags are allowed, so it strips nothing
+        (
+            "a test <em>with</em> <b>html</b> tags",
+            {},
+            "a test <em>with</em> <b>html</b> tags",
+        ),
+        # img tag is disallowed, so it's stripped
+        (
+            'a test <em>with</em> <img src="http://example.com/"> <b>html</b> tags',
+            {},
+            "a test <em>with</em>  <b>html</b> tags",
+        ),
+        # a tag is disallowed, so it's stripped
+        (
+            '<p><a href="http://example.com/">link text</a></p>',
+            {"tags": ["p"]},
+            "<p>link text</p>",
+        ),
+        # Test nested disallowed tag
+        (
+            "<p><span>multiply <span>nested <span>text</span></span></span></p>",
+            {"tags": ["p"]},
+            "<p>multiply nested text</p>",
+        ),
+        # (#271)
+        ("<ul><li><script></li></ul>", {"tags": ["ul", "li"]}, "<ul><li></li></ul>"),
+        # Test disallowed tag that's deep in the tree
+        (
+            '<p><a href="http://example.com/"><img src="http://example.com/"></a></p>',
+            {"tags": ["a", "p"]},
+            '<p><a href="http://example.com/"></a></p>',
+        ),
+        # Test isindex -- the parser expands this to a prompt (#279)
+        ("<isindex>", {}, ""),
+        # Test non-tags that are well-formed HTML (#280)
+        ("Yeah right <sarcasm/>", {}, "Yeah right "),
+        ("<sarcasm>", {}, ""),
+        ("</sarcasm>", {}, ""),
+        # These are non-tags, but also "malformed" so they don't get treated like
+        # tags and stripped
+        ("</ sarcasm>", {}, "&lt;/ sarcasm&gt;"),
+        ("</ sarcasm >", {}, "&lt;/ sarcasm &gt;"),
+        ("Foo <bar@example.com>", {}, "Foo "),
+        ("Favorite movie: <name of movie>", {}, "Favorite movie: "),
+        ("</3", {}, "&lt;/3"),
+    ],
+)
 def test_stripping_tags(data, kwargs, expected):
     assert clean(data, strip=True, **kwargs) == expected
-    assert clean('  ' + data + '  ', strip=True, **kwargs) == '  ' + expected + '  '
-    assert clean('abc ' + data + ' def', strip=True, **kwargs) == 'abc ' + expected + ' def'
+    assert clean("  " + data + "  ", strip=True, **kwargs) == "  " + expected + "  "
+    assert (
+        clean("abc " + data + " def", strip=True, **kwargs)
+        == "abc " + expected + " def"
+    )
 
 
-@pytest.mark.parametrize('data, expected', [
-    # Disallowed tag is escaped
-    ('<img src="javascript:alert(\'XSS\');">', '&lt;img src="javascript:alert(\'XSS\');"&gt;'),
-
-    # Test with parens
-    ('<script>safe()</script>', '&lt;script&gt;safe()&lt;/script&gt;'),
-
-    # Test with braces
-    ('<style>body{}</style>', '&lt;style&gt;body{}&lt;/style&gt;'),
-
-    # Test nested disallow tags (#271)
-    ('<ul><li><script></li></ul>', '<ul><li>&lt;script&gt;</li></ul>'),
-
-    # Test isindex -- the parser expands this to a prompt (#279)
-    ('<isindex>', '&lt;isindex&gt;'),
-
-    # Test non-tags (#280)
-    ('<sarcasm/>', '&lt;sarcasm/&gt;'),
-    ('<sarcasm>', '&lt;sarcasm&gt;'),
-    ('</sarcasm>', '&lt;/sarcasm&gt;'),
-    ('</ sarcasm>', '&lt;/ sarcasm&gt;'),
-    ('</ sarcasm >', '&lt;/ sarcasm &gt;'),
-    ('</3', '&lt;/3'),
-    ('<bar@example.com>', '&lt;bar@example.com&gt;'),
-    ('Favorite movie: <name of movie>', 'Favorite movie: &lt;name of movie&gt;'),
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # Disallowed tag is escaped
+        (
+            "<img src=\"javascript:alert('XSS');\">",
+            "&lt;img src=\"javascript:alert('XSS');\"&gt;",
+        ),
+        # Test with parens
+        ("<script>safe()</script>", "&lt;script&gt;safe()&lt;/script&gt;"),
+        # Test with braces
+        ("<style>body{}</style>", "&lt;style&gt;body{}&lt;/style&gt;"),
+        # Test nested disallow tags (#271)
+        ("<ul><li><script></li></ul>", "<ul><li>&lt;script&gt;</li></ul>"),
+        # Test isindex -- the parser expands this to a prompt (#279)
+        ("<isindex>", "&lt;isindex&gt;"),
+        # Test non-tags (#280)
+        ("<sarcasm/>", "&lt;sarcasm/&gt;"),
+        ("<sarcasm>", "&lt;sarcasm&gt;"),
+        ("</sarcasm>", "&lt;/sarcasm&gt;"),
+        ("</ sarcasm>", "&lt;/ sarcasm&gt;"),
+        ("</ sarcasm >", "&lt;/ sarcasm &gt;"),
+        ("</3", "&lt;/3"),
+        ("<bar@example.com>", "&lt;bar@example.com&gt;"),
+        ("Favorite movie: <name of movie>", "Favorite movie: &lt;name of movie&gt;"),
+    ],
+)
 def test_escaping_tags(data, expected):
     assert clean(data, strip=False) == expected
-    assert clean('  ' + data + '  ', strip=False) == '  ' + expected + '  '
-    assert clean('abc ' + data + ' def', strip=False) == 'abc ' + expected + ' def'
+    assert clean("  " + data + "  ", strip=False) == "  " + expected + "  "
+    assert clean("abc " + data + " def", strip=False) == "abc " + expected + " def"
 
 
-@pytest.mark.parametrize('data, expected', [
-    (
-        '<scri<script>pt>alert(1)</scr</script>ipt>',
-        'pt&gt;alert(1)ipt&gt;'
-    ),
-    (
-        '<scri<scri<script>pt>pt>alert(1)</script>',
-        'pt&gt;pt&gt;alert(1)'
-    ),
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        ("<scri<script>pt>alert(1)</scr</script>ipt>", "pt&gt;alert(1)ipt&gt;"),
+        ("<scri<scri<script>pt>pt>alert(1)</script>", "pt&gt;pt&gt;alert(1)"),
+    ],
+)
 def test_stripping_tags_is_safe(data, expected):
     """Test stripping tags shouldn't result in malicious content"""
     assert clean(data, strip=True) == expected
@@ -383,86 +306,86 @@ def test_stripping_tags_is_safe(data, expected):
 
 def test_allowed_styles():
     """Test allowed styles"""
-    ATTRS = ['style']
-    STYLE = ['color']
+    ATTRS = ["style"]
+    STYLE = ["color"]
 
-    assert (
-        clean('<b style="top:0"></b>', attributes=ATTRS) ==
-        '<b style=""></b>'
-    )
+    assert clean('<b style="top:0"></b>', attributes=ATTRS) == '<b style=""></b>'
 
     text = '<b style="color: blue;"></b>'
     assert clean(text, attributes=ATTRS, styles=STYLE) == text
 
     text = '<b style="top: 0; color: blue;"></b>'
-    assert (
-        clean(text, attributes=ATTRS, styles=STYLE) ==
-        '<b style="color: blue;"></b>'
-    )
+    assert clean(text, attributes=ATTRS, styles=STYLE) == '<b style="color: blue;"></b>'
 
 
 def test_href_with_wrong_tag():
-    assert (
-        clean('<em href="fail">no link</em>') ==
-        '<em>no link</em>'
-    )
+    assert clean('<em href="fail">no link</em>') == "<em>no link</em>"
 
 
 def test_disallowed_attr():
-    IMG = ['img', ]
-    IMG_ATTR = ['src']
+    IMG = [
+        "img",
+    ]
+    IMG_ATTR = ["src"]
 
+    assert clean('<a onclick="evil" href="test">test</a>') == '<a href="test">test</a>'
     assert (
-        clean('<a onclick="evil" href="test">test</a>') ==
-        '<a href="test">test</a>'
+        clean('<img onclick="evil" src="test" />', tags=IMG, attributes=IMG_ATTR)
+        == '<img src="test">'
     )
     assert (
-        clean('<img onclick="evil" src="test" />', tags=IMG, attributes=IMG_ATTR) ==
-        '<img src="test">'
-    )
-    assert (
-        clean('<img href="invalid" src="test" />', tags=IMG, attributes=IMG_ATTR) ==
-        '<img src="test">'
+        clean('<img href="invalid" src="test" />', tags=IMG, attributes=IMG_ATTR)
+        == '<img src="test">'
     )
 
 
 def test_unquoted_attr_values_are_quoted():
     assert (
-        clean('<abbr title=mytitle>myabbr</abbr>') ==
-        '<abbr title="mytitle">myabbr</abbr>'
+        clean("<abbr title=mytitle>myabbr</abbr>")
+        == '<abbr title="mytitle">myabbr</abbr>'
     )
 
 
 def test_unquoted_event_handler_attr_value():
     assert (
-        clean('<a href="http://xx.com" onclick=foo()>xx.com</a>') ==
-        '<a href="http://xx.com">xx.com</a>'
+        clean('<a href="http://xx.com" onclick=foo()>xx.com</a>')
+        == '<a href="http://xx.com">xx.com</a>'
     )
 
 
 def test_invalid_filter_attr():
-    IMG = ['img', ]
+    IMG = [
+        "img",
+    ]
     IMG_ATTR = {
-        'img': lambda tag, name, val: name == 'src' and val == "http://example.com/"
+        "img": lambda tag, name, val: name == "src" and val == "http://example.com/"
     }
 
     assert (
-        clean('<img onclick="evil" src="http://example.com/" />', tags=IMG, attributes=IMG_ATTR) ==
-        '<img src="http://example.com/">'
+        clean(
+            '<img onclick="evil" src="http://example.com/" />',
+            tags=IMG,
+            attributes=IMG_ATTR,
+        )
+        == '<img src="http://example.com/">'
     )
     assert (
-        clean('<img onclick="evil" src="http://badhost.com/" />', tags=IMG, attributes=IMG_ATTR) ==
-        '<img>'
+        clean(
+            '<img onclick="evil" src="http://badhost.com/" />',
+            tags=IMG,
+            attributes=IMG_ATTR,
+        )
+        == "<img>"
     )
 
 
 def test_poster_attribute():
     """Poster attributes should not allow javascript."""
-    tags = ['video']
-    attrs = {'video': ['poster']}
+    tags = ["video"]
+    attrs = {"video": ["poster"]}
 
     test = '<video poster="javascript:alert(1)"></video>'
-    assert clean(test, tags=tags, attributes=attrs) == '<video></video>'
+    assert clean(test, tags=tags, attributes=attrs) == "<video></video>"
 
     ok = '<video poster="/foo.png"></video>'
     assert clean(ok, tags=tags, attributes=attrs) == ok
@@ -470,210 +393,155 @@ def test_poster_attribute():
 
 def test_attributes_callable():
     """Verify attributes can take a callable"""
-    ATTRS = lambda tag, name, val: name == 'title'
-    TAGS = ['a']
+    ATTRS = lambda tag, name, val: name == "title"
+    TAGS = ["a"]
 
     text = '<a href="/foo" title="blah">example</a>'
-    assert (
-        clean(text, tags=TAGS, attributes=ATTRS) ==
-        '<a title="blah">example</a>'
-    )
+    assert clean(text, tags=TAGS, attributes=ATTRS) == '<a title="blah">example</a>'
 
 
 def test_attributes_wildcard():
     """Verify attributes[*] works"""
     ATTRS = {
-        '*': ['id'],
-        'img': ['src'],
+        "*": ["id"],
+        "img": ["src"],
     }
-    TAGS = ['img', 'em']
+    TAGS = ["img", "em"]
 
-    text = 'both <em id="foo" style="color: black">can</em> have <img id="bar" src="foo"/>'
+    text = (
+        'both <em id="foo" style="color: black">can</em> have <img id="bar" src="foo"/>'
+    )
     assert (
-        clean(text, tags=TAGS, attributes=ATTRS) ==
-        'both <em id="foo">can</em> have <img id="bar" src="foo">'
+        clean(text, tags=TAGS, attributes=ATTRS)
+        == 'both <em id="foo">can</em> have <img id="bar" src="foo">'
     )
 
 
 def test_attributes_wildcard_callable():
     """Verify attributes[*] callable works"""
-    ATTRS = {
-        '*': lambda tag, name, val: name == 'title'
-    }
-    TAGS = ['a']
+    ATTRS = {"*": lambda tag, name, val: name == "title"}
+    TAGS = ["a"]
 
     assert (
-        clean('<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS) ==
-        '<a title="blah">example</a>'
+        clean('<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS)
+        == '<a title="blah">example</a>'
     )
 
 
 def test_attributes_tag_callable():
     """Verify attributes[tag] callable works"""
+
     def img_test(tag, name, val):
-        return name == 'src' and val.startswith('https')
+        return name == "src" and val.startswith("https")
 
     ATTRS = {
-        'img': img_test,
+        "img": img_test,
     }
-    TAGS = ['img']
+    TAGS = ["img"]
 
     text = 'foo <img src="http://example.com" alt="blah"> baz'
-    assert (
-        clean(text, tags=TAGS, attributes=ATTRS) ==
-        'foo <img> baz'
-    )
+    assert clean(text, tags=TAGS, attributes=ATTRS) == "foo <img> baz"
     text = 'foo <img src="https://example.com" alt="blah"> baz'
     assert (
-        clean(text, tags=TAGS, attributes=ATTRS) ==
-        'foo <img src="https://example.com"> baz'
+        clean(text, tags=TAGS, attributes=ATTRS)
+        == 'foo <img src="https://example.com"> baz'
     )
 
 
 def test_attributes_tag_list():
     """Verify attributes[tag] list works"""
-    ATTRS = {
-        'a': ['title']
-    }
-    TAGS = ['a']
+    ATTRS = {"a": ["title"]}
+    TAGS = ["a"]
 
     assert (
-        clean('<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS) ==
-        '<a title="blah">example</a>'
+        clean('<a href="/foo" title="blah">example</a>', tags=TAGS, attributes=ATTRS)
+        == '<a title="blah">example</a>'
     )
 
 
 def test_attributes_list():
     """Verify attributes list works"""
-    ATTRS = ['title']
-    TAGS = ['a']
+    ATTRS = ["title"]
+    TAGS = ["a"]
 
     text = '<a href="/foo" title="blah">example</a>'
-    assert (
-        clean(text, tags=TAGS, attributes=ATTRS) ==
-        '<a title="blah">example</a>'
-    )
+    assert clean(text, tags=TAGS, attributes=ATTRS) == '<a title="blah">example</a>'
 
 
-@pytest.mark.parametrize('data, kwargs, expected', [
-    # javascript: is not allowed by default
-    (
-        '<a href="javascript:alert(\'XSS\')">xss</a>',
-        {},
-        '<a>xss</a>'
-    ),
-
-    # File protocol is not allowed by default
-    (
-        '<a href="file:///tmp/foo">foo</a>',
-        {},
-        '<a>foo</a>'
-    ),
-
-    # Specified protocols are allowed
-    (
-        '<a href="myprotocol://more_text">allowed href</a>',
-        {'protocols': ['myprotocol']},
-        '<a href="myprotocol://more_text">allowed href</a>'
-    ),
-
-    # Unspecified protocols are not allowed
-    (
-        '<a href="http://example.com">invalid href</a>',
-        {'protocols': ['myprotocol']},
-        '<a>invalid href</a>'
-    ),
-
-    # Anchors are ok
-    (
-        '<a href="#example.com">foo</a>',
-        {'protocols': []},
-        '<a href="#example.com">foo</a>'
-    ),
-
-    # Allow implicit http if allowed
-    (
-        '<a href="example.com">valid</a>',
-        {'protocols': ['http']},
-        '<a href="example.com">valid</a>'
-    ),
-    (
-        '<a href="example.com:8000">valid</a>',
-        {'protocols': ['http']},
-        '<a href="example.com:8000">valid</a>'
-    ),
-    (
-        '<a href="localhost">valid</a>',
-        {'protocols': ['http']},
-        '<a href="localhost">valid</a>'
-    ),
-    (
-        '<a href="localhost:8000">valid</a>',
-        {'protocols': ['http']},
-        '<a href="localhost:8000">valid</a>'
-    ),
-    (
-        '<a href="192.168.100.100">valid</a>',
-        {'protocols': ['http']},
-        '<a href="192.168.100.100">valid</a>'
-    ),
-    (
-        '<a href="192.168.100.100:8000">valid</a>',
-        {'protocols': ['http']},
-        '<a href="192.168.100.100:8000">valid</a>'
-    ),
-
-    # Disallow implicit http if disallowed
-    (
-        '<a href="example.com">foo</a>',
-        {'protocols': []},
-        '<a>foo</a>'
-    ),
-    (
-        '<a href="example.com:8000">foo</a>',
-        {'protocols': []},
-        '<a>foo</a>'
-    ),
-    (
-        '<a href="localhost">foo</a>',
-        {'protocols': []},
-        '<a>foo</a>'
-    ),
-    (
-        '<a href="localhost:8000">foo</a>',
-        {'protocols': []},
-        '<a>foo</a>'
-    ),
-    (
-        '<a href="192.168.100.100">foo</a>',
-        {'protocols': []},
-        '<a>foo</a>'
-    ),
-    (
-        '<a href="192.168.100.100:8000">foo</a>',
-        {'protocols': []},
-        '<a>foo</a>'
-    ),
-
-    # Disallowed protocols with sneaky character entities
-    (
-        '<a href="javas&#x09;cript:alert(1)">alert</a>',
-        {},
-        '<a>alert</a>'
-    ),
-    (
-        '<a href="&#14;javascript:alert(1)">alert</a>',
-        {},
-        '<a>alert</a>'
-    ),
-
-    # Checking the uri should change it at all
-    (
-        '<a href="http://example.com/?foo&nbsp;bar">foo</a>',
-        {},
-        '<a href="http://example.com/?foo&nbsp;bar">foo</a>'
-    ),
-])
+@pytest.mark.parametrize(
+    "data, kwargs, expected",
+    [
+        # javascript: is not allowed by default
+        ("<a href=\"javascript:alert('XSS')\">xss</a>", {}, "<a>xss</a>"),
+        # File protocol is not allowed by default
+        ('<a href="file:///tmp/foo">foo</a>', {}, "<a>foo</a>"),
+        # Specified protocols are allowed
+        (
+            '<a href="myprotocol://more_text">allowed href</a>',
+            {"protocols": ["myprotocol"]},
+            '<a href="myprotocol://more_text">allowed href</a>',
+        ),
+        # Unspecified protocols are not allowed
+        (
+            '<a href="http://example.com">invalid href</a>',
+            {"protocols": ["myprotocol"]},
+            "<a>invalid href</a>",
+        ),
+        # Anchors are ok
+        (
+            '<a href="#example.com">foo</a>',
+            {"protocols": []},
+            '<a href="#example.com">foo</a>',
+        ),
+        # Allow implicit http if allowed
+        (
+            '<a href="example.com">valid</a>',
+            {"protocols": ["http"]},
+            '<a href="example.com">valid</a>',
+        ),
+        (
+            '<a href="example.com:8000">valid</a>',
+            {"protocols": ["http"]},
+            '<a href="example.com:8000">valid</a>',
+        ),
+        (
+            '<a href="localhost">valid</a>',
+            {"protocols": ["http"]},
+            '<a href="localhost">valid</a>',
+        ),
+        (
+            '<a href="localhost:8000">valid</a>',
+            {"protocols": ["http"]},
+            '<a href="localhost:8000">valid</a>',
+        ),
+        (
+            '<a href="192.168.100.100">valid</a>',
+            {"protocols": ["http"]},
+            '<a href="192.168.100.100">valid</a>',
+        ),
+        (
+            '<a href="192.168.100.100:8000">valid</a>',
+            {"protocols": ["http"]},
+            '<a href="192.168.100.100:8000">valid</a>',
+        ),
+        # Disallow implicit http if disallowed
+        ('<a href="example.com">foo</a>', {"protocols": []}, "<a>foo</a>"),
+        ('<a href="example.com:8000">foo</a>', {"protocols": []}, "<a>foo</a>"),
+        ('<a href="localhost">foo</a>', {"protocols": []}, "<a>foo</a>"),
+        ('<a href="localhost:8000">foo</a>', {"protocols": []}, "<a>foo</a>"),
+        ('<a href="192.168.100.100">foo</a>', {"protocols": []}, "<a>foo</a>"),
+        ('<a href="192.168.100.100:8000">foo</a>', {"protocols": []}, "<a>foo</a>"),
+        # Disallowed protocols with sneaky character entities
+        ('<a href="javas&#x09;cript:alert(1)">alert</a>', {}, "<a>alert</a>"),
+        ('<a href="&#14;javascript:alert(1)">alert</a>', {}, "<a>alert</a>"),
+        # Checking the uri should change it at all
+        (
+            '<a href="http://example.com/?foo&nbsp;bar">foo</a>',
+            {},
+            '<a href="http://example.com/?foo&nbsp;bar">foo</a>',
+        ),
+    ],
+)
 def test_uri_value_allowed_protocols(data, kwargs, expected):
     assert clean(data, **kwargs) == expected
 
@@ -681,84 +549,86 @@ def test_uri_value_allowed_protocols(data, kwargs, expected):
 def test_svg_attr_val_allows_ref():
     """Unescape values in svg attrs that allow url references"""
     # Local IRI, so keep it
-    TAGS = ['svg', 'rect']
+    TAGS = ["svg", "rect"]
     ATTRS = {
-        'rect': ['fill'],
+        "rect": ["fill"],
     }
 
     text = '<svg><rect fill="url(#foo)" /></svg>'
     assert (
-        clean(text, tags=TAGS, attributes=ATTRS) ==
-        '<svg><rect fill="url(#foo)"></rect></svg>'
+        clean(text, tags=TAGS, attributes=ATTRS)
+        == '<svg><rect fill="url(#foo)"></rect></svg>'
     )
 
     # Non-local IRI, so drop it
-    TAGS = ['svg', 'rect']
+    TAGS = ["svg", "rect"]
     ATTRS = {
-        'rect': ['fill'],
+        "rect": ["fill"],
     }
     text = '<svg><rect fill="url(http://example.com#foo)" /></svg>'
-    assert (
-        clean(text, tags=TAGS, attributes=ATTRS) ==
-        '<svg><rect></rect></svg>'
-    )
+    assert clean(text, tags=TAGS, attributes=ATTRS) == "<svg><rect></rect></svg>"
 
 
-@pytest.mark.parametrize('text, expected', [
-    (
-        '<svg><pattern id="patt1" href="#patt2"></pattern></svg>',
-        '<svg><pattern href="#patt2" id="patt1"></pattern></svg>'
-    ),
-    (
-        '<svg><pattern id="patt1" xlink:href="#patt2"></pattern></svg>',
-        # NOTE(willkg): Bug in html5lib serializer drops the xlink part
-        '<svg><pattern id="patt1" href="#patt2"></pattern></svg>'
-    ),
-])
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        (
+            '<svg><pattern id="patt1" href="#patt2"></pattern></svg>',
+            '<svg><pattern href="#patt2" id="patt1"></pattern></svg>',
+        ),
+        (
+            '<svg><pattern id="patt1" xlink:href="#patt2"></pattern></svg>',
+            # NOTE(willkg): Bug in html5lib serializer drops the xlink part
+            '<svg><pattern id="patt1" href="#patt2"></pattern></svg>',
+        ),
+    ],
+)
 def test_svg_allow_local_href(text, expected):
     """Keep local hrefs for svg elements"""
-    TAGS = ['svg', 'pattern']
+    TAGS = ["svg", "pattern"]
     ATTRS = {
-        'pattern': ['id', 'href'],
+        "pattern": ["id", "href"],
     }
     assert clean(text, tags=TAGS, attributes=ATTRS) == expected
 
 
-@pytest.mark.parametrize('text, expected', [
-    (
-        '<svg><pattern id="patt1" href="https://example.com/patt"></pattern></svg>',
-        '<svg><pattern id="patt1"></pattern></svg>'
-    ),
-    (
-        '<svg><pattern id="patt1" xlink:href="https://example.com/patt"></pattern></svg>',
-        '<svg><pattern id="patt1"></pattern></svg>'
-    ),
-])
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        (
+            '<svg><pattern id="patt1" href="https://example.com/patt"></pattern></svg>',
+            '<svg><pattern id="patt1"></pattern></svg>',
+        ),
+        (
+            '<svg><pattern id="patt1" xlink:href="https://example.com/patt"></pattern></svg>',
+            '<svg><pattern id="patt1"></pattern></svg>',
+        ),
+    ],
+)
 def test_svg_allow_local_href_nonlocal(text, expected):
     """Drop non-local hrefs for svg elements"""
-    TAGS = ['svg', 'pattern']
+    TAGS = ["svg", "pattern"]
     ATTRS = {
-        'pattern': ['id', 'href'],
+        "pattern": ["id", "href"],
     }
     assert clean(text, tags=TAGS, attributes=ATTRS) == expected
 
 
-@pytest.mark.parametrize('data, expected', [
-    # Convert bell
-    ('1\a23', '1?23'),
-
-    # Convert backpsace
-    ('1\b23', '1?23'),
-
-    # Convert formfeed
-    ('1\v23', '1?23'),
-
-    # Convert vertical tab
-    ('1\f23', '1?23'),
-
-    # Convert a bunch of characters in a string
-    ('import y\bose\bm\bi\bt\be\b', 'import y?ose?m?i?t?e?'),
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # Convert bell
+        ("1\a23", "1?23"),
+        # Convert backpsace
+        ("1\b23", "1?23"),
+        # Convert formfeed
+        ("1\v23", "1?23"),
+        # Convert vertical tab
+        ("1\f23", "1?23"),
+        # Convert a bunch of characters in a string
+        ("import y\bose\bm\bi\bt\be\b", "import y?ose?m?i?t?e?"),
+    ],
+)
 def test_invisible_characters(data, expected):
     assert clean(data) == expected
 
@@ -768,7 +638,7 @@ def test_nonexistent_namespace():
     # namespace didn't exist. After the fixes for Bleach 3.0, this no longer
     # goes through the HTML parser as a tag, so it doesn't tickle the bad
     # namespace code.
-    assert clean('<d {c}>') == '&lt;d {c}&gt;'
+    assert clean("<d {c}>") == "&lt;d {c}&gt;"
 
 
 @pytest.mark.parametrize(
@@ -822,13 +692,15 @@ _raw_tags = [
     "xmp",
 ]
 
+
 @pytest.mark.parametrize(
     "raw_tag, data, expected",
     [
         (
             raw_tag,
             "<noscript><%s></noscript><img src=x onerror=alert(1) />" % raw_tag,
-            "<noscript>&lt;%s&gt;</noscript>&lt;img src=x onerror=alert(1) /&gt;" % raw_tag,
+            "<noscript>&lt;%s&gt;</noscript>&lt;img src=x onerror=alert(1) /&gt;"
+            % raw_tag,
         )
         for raw_tag in _raw_tags
     ],
@@ -844,8 +716,10 @@ def test_noscript_rawtag_(raw_tag, data, expected):
         (
             namespace_tag,
             rc_data_element_tag,
-            "<%s><%s><img src=x onerror=alert(1)>" % (namespace_tag, rc_data_element_tag),
-            "<%s><%s>&lt;img src=x onerror=alert(1)&gt;</%s></%s>" % (namespace_tag, rc_data_element_tag, rc_data_element_tag, namespace_tag),
+            "<%s><%s><img src=x onerror=alert(1)>"
+            % (namespace_tag, rc_data_element_tag),
+            "<%s><%s>&lt;img src=x onerror=alert(1)&gt;</%s></%s>"
+            % (namespace_tag, rc_data_element_tag, rc_data_element_tag, namespace_tag),
         )
         for namespace_tag in ["math", "svg"]
         # https://dev.w3.org/html5/html-author/#rcdata-elements
@@ -854,11 +728,15 @@ def test_noscript_rawtag_(raw_tag, data, expected):
         for rc_data_element_tag in rcdataElements
     ],
 )
-def test_namespace_rc_data_element_strip_false(namespace_tag, rc_data_element_tag, data, expected):
+def test_namespace_rc_data_element_strip_false(
+    namespace_tag, rc_data_element_tag, data, expected
+):
     # refs: bug 1621692 / GHSA-m6xf-fq7q-8743
     #
     # browsers will pull the img out of the namespace and rc data tag resulting in XSS
-    assert clean(data, tags=[namespace_tag, rc_data_element_tag], strip=False) == expected
+    assert (
+        clean(data, tags=[namespace_tag, rc_data_element_tag], strip=False) == expected
+    )
 
 
 def get_ids_and_tests():
@@ -867,13 +745,12 @@ def get_ids_and_tests():
     :returns: list of ``(id, filedata)`` tuples
 
     """
-    datadir = os.path.join(os.path.dirname(__file__), 'data')
+    datadir = os.path.join(os.path.dirname(__file__), "data")
     tests = [
-        os.path.join(datadir, fn) for fn in os.listdir(datadir)
-        if fn.endswith('.test')
+        os.path.join(datadir, fn) for fn in os.listdir(datadir) if fn.endswith(".test")
     ]
     # Sort numerically which makes it easier to iterate through them
-    tests.sort(key=lambda x: int(os.path.basename(x).split('.', 1)[0]))
+    tests.sort(key=lambda x: int(os.path.basename(x).split(".", 1)[0]))
 
     testcases = []
     for fn in tests:
@@ -889,10 +766,10 @@ _regression_ids = [item[0] for item in _regression_ids_and_tests]
 _regression_tests = [item[1] for item in _regression_ids_and_tests]
 
 
-@pytest.mark.parametrize('test_case', _regression_tests, ids=_regression_ids)
+@pytest.mark.parametrize("test_case", _regression_tests, ids=_regression_ids)
 def test_regressions(test_case):
     """Regression tests for clean so we can see if there are issues"""
-    test_data, expected = test_case.split('\n--\n')
+    test_data, expected = test_case.split("\n--\n")
 
     # NOTE(willkg): This strips input and expected which makes it easier to
     # maintain the files. If there comes a time when the input needs whitespace
@@ -905,14 +782,14 @@ def test_regressions(test_case):
 
 class TestCleaner:
     def test_basics(self):
-        TAGS = ['span', 'br']
-        ATTRS = {'span': ['style']}
+        TAGS = ["span", "br"]
+        ATTRS = {"span": ["style"]}
 
         cleaner = Cleaner(tags=TAGS, attributes=ATTRS)
 
         assert (
-            cleaner.clean('a <br/><span style="color:red">test</span>') ==
-            'a <br><span style="">test</span>'
+            cleaner.clean('a <br/><span style="color:red">test</span>')
+            == 'a <br><span style="">test</span>'
         )
 
     def test_filters(self):
@@ -920,21 +797,16 @@ class TestCleaner:
         class MooFilter(Filter):
             def __iter__(self):
                 for token in Filter.__iter__(self):
-                    if token['type'] in ['StartTag', 'EmptyTag'] and token['data']:
-                        for attr, value in token['data'].items():
-                            token['data'][attr] = 'moo'
+                    if token["type"] in ["StartTag", "EmptyTag"] and token["data"]:
+                        for attr, value in token["data"].items():
+                            token["data"][attr] = "moo"
 
                     yield token
 
-        ATTRS = {
-            'img': ['rel', 'src']
-        }
-        TAGS = ['img']
+        ATTRS = {"img": ["rel", "src"]}
+        TAGS = ["img"]
 
         cleaner = Cleaner(tags=TAGS, attributes=ATTRS, filters=[MooFilter])
 
         dirty = 'this is cute! <img src="http://example.com/puppy.jpg" rel="nofollow">'
-        assert (
-            cleaner.clean(dirty) ==
-            'this is cute! <img rel="moo" src="moo">'
-        )
+        assert cleaner.clean(dirty) == 'this is cute! <img rel="moo" src="moo">'

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -8,239 +8,264 @@ import pytest
 from bleach import clean
 
 
-clean = partial(clean, tags=['p'], attributes=['style'])
+clean = partial(clean, tags=["p"], attributes=["style"])
 
 
-@pytest.mark.parametrize('data, styles, expected', [
-    (
-        '<p style="font-family: Arial; color: red; float: left; background-color: red;">bar</p>',
-        ['color'],
-        '<p style="color: red;">bar</p>'
-    ),
-    (
-        '<p style="border: 1px solid blue; color: red; float: left;">bar</p>',
-        ['color'],
-        '<p style="color: red;">bar</p>'
-    ),
-    (
-        '<p style="border: 1px solid blue; color: red; float: left;">bar</p>',
-        ['color', 'float'],
-        '<p style="color: red; float: left;">bar</p>'
-    ),
-    (
-        '<p style="color: red; float: left; padding: 1em;">bar</p>',
-        ['color', 'float'],
-        '<p style="color: red; float: left;">bar</p>'
-    ),
-    (
-        '<p style="color: red; float: left; padding: 1em;">bar</p>',
-        ['color'],
-        '<p style="color: red;">bar</p>'
-    ),
-    # Handle leading - in attributes
-    # regressed with the fix for bug 1623633
-    pytest.param(
-        '<p style="cursor: -moz-grab;">bar</p>',
-        ['cursor'],
-        '<p style="cursor: -moz-grab;">bar</p>',
-        marks=pytest.mark.xfail,
-    ),
-    # Handle () in attributes
-    (
-        '<p style="color: hsl(30,100%,50%);">bar</p>',
-        ['color'],
-        '<p style="color: hsl(30,100%,50%);">bar</p>',
-    ),
-    (
-        '<p style="color: rgba(255,0,0,0.4);">bar</p>',
-        ['color'],
-        '<p style="color: rgba(255,0,0,0.4);">bar</p>',
-    ),
-    # Handle ' in attributes
-    # regressed with the fix for bug 1623633
-    pytest.param(
-        '<p style="text-overflow: \',\' ellipsis;">bar</p>',
-        ['text-overflow'],
-        '<p style="text-overflow: \',\' ellipsis;">bar</p>',
-        marks=pytest.mark.xfail,
-    ),
-    # Handle " in attributes
-    # regressed with the fix for bug 1623633
-    pytest.param(
-        '<p style=\'text-overflow: "," ellipsis;\'>bar</p>',
-        ['text-overflow'],
-        '<p style=\'text-overflow: "," ellipsis;\'>bar</p>',
-        marks=pytest.mark.xfail,
-    ),
-    (
-        '<p style=\'font-family: "Arial";\'>bar</p>',
-        ['font-family'],
-        '<p style=\'font-family: "Arial";\'>bar</p>'
-    ),
-    # Handle non-ascii characters in attributes
-    (
-        '<p style="font-family: \u30e1\u30a4\u30ea\u30aa; color: blue;">bar</p>',
-        ['color'],
-        '<p style="color: blue;">bar</p>'
-    ),
-])
+@pytest.mark.parametrize(
+    "data, styles, expected",
+    [
+        (
+            '<p style="font-family: Arial; color: red; float: left; background-color: red;">bar</p>',
+            ["color"],
+            '<p style="color: red;">bar</p>',
+        ),
+        (
+            '<p style="border: 1px solid blue; color: red; float: left;">bar</p>',
+            ["color"],
+            '<p style="color: red;">bar</p>',
+        ),
+        (
+            '<p style="border: 1px solid blue; color: red; float: left;">bar</p>',
+            ["color", "float"],
+            '<p style="color: red; float: left;">bar</p>',
+        ),
+        (
+            '<p style="color: red; float: left; padding: 1em;">bar</p>',
+            ["color", "float"],
+            '<p style="color: red; float: left;">bar</p>',
+        ),
+        (
+            '<p style="color: red; float: left; padding: 1em;">bar</p>',
+            ["color"],
+            '<p style="color: red;">bar</p>',
+        ),
+        # Handle leading - in attributes
+        # regressed with the fix for bug 1623633
+        pytest.param(
+            '<p style="cursor: -moz-grab;">bar</p>',
+            ["cursor"],
+            '<p style="cursor: -moz-grab;">bar</p>',
+            marks=pytest.mark.xfail,
+        ),
+        # Handle () in attributes
+        (
+            '<p style="color: hsl(30,100%,50%);">bar</p>',
+            ["color"],
+            '<p style="color: hsl(30,100%,50%);">bar</p>',
+        ),
+        (
+            '<p style="color: rgba(255,0,0,0.4);">bar</p>',
+            ["color"],
+            '<p style="color: rgba(255,0,0,0.4);">bar</p>',
+        ),
+        # Handle ' in attributes
+        # regressed with the fix for bug 1623633
+        pytest.param(
+            "<p style=\"text-overflow: ',' ellipsis;\">bar</p>",
+            ["text-overflow"],
+            "<p style=\"text-overflow: ',' ellipsis;\">bar</p>",
+            marks=pytest.mark.xfail,
+        ),
+        # Handle " in attributes
+        # regressed with the fix for bug 1623633
+        pytest.param(
+            "<p style='text-overflow: \",\" ellipsis;'>bar</p>",
+            ["text-overflow"],
+            "<p style='text-overflow: \",\" ellipsis;'>bar</p>",
+            marks=pytest.mark.xfail,
+        ),
+        (
+            "<p style='font-family: \"Arial\";'>bar</p>",
+            ["font-family"],
+            "<p style='font-family: \"Arial\";'>bar</p>",
+        ),
+        # Handle non-ascii characters in attributes
+        (
+            '<p style="font-family: \u30e1\u30a4\u30ea\u30aa; color: blue;">bar</p>',
+            ["color"],
+            '<p style="color: blue;">bar</p>',
+        ),
+    ],
+)
 def test_allowed_css(data, styles, expected):
     assert clean(data, styles=styles) == expected
 
 
 def test_valid_css():
     """The sanitizer should fix missing CSS values."""
-    styles = ['color', 'float']
+    styles = ["color", "float"]
     assert (
-        clean('<p style="float: left; color: ">foo</p>', styles=styles) ==
-        '<p style="float: left;">foo</p>'
+        clean('<p style="float: left; color: ">foo</p>', styles=styles)
+        == '<p style="float: left;">foo</p>'
     )
     assert (
-        clean('<p style="color: float: left;">foo</p>', styles=styles) ==
-        '<p style="">foo</p>'
+        clean('<p style="color: float: left;">foo</p>', styles=styles)
+        == '<p style="">foo</p>'
     )
 
 
-@pytest.mark.parametrize('data, expected', [
-    # No url--unchanged
-    (
-        '<p style="background: #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-
-    # Verify urls with no quotes, single quotes, and double quotes are all dropped
-    (
-        '<p style="background: url(topbanner.png) #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-    (
-        '<p style="background: url(\'topbanner.png\') #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-    (
-        '<p style=\'background: url("topbanner.png") #00D;\'>foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-
-    # Verify urls with spacing
-    (
-        '<p style="background: url(  \'topbanner.png\') #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-    (
-        '<p style="background: url(\'topbanner.png\'  ) #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-    (
-        '<p style="background: url(  \'topbanner.png\'  ) #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-    (
-        '<p style="background: url (  \'topbanner.png\'  ) #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-
-    # Verify urls with character entities
-    (
-        '<p style="background: url&#x09;(\'topbanner.png\') #00D;">foo</p>',
-        '<p style="background: #00D;">foo</p>'
-    ),
-
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # No url--unchanged
+        (
+            '<p style="background: #00D;">foo</p>',
+            '<p style="background: #00D;">foo</p>',
+        ),
+        # Verify urls with no quotes, single quotes, and double quotes are all dropped
+        (
+            '<p style="background: url(topbanner.png) #00D;">foo</p>',
+            '<p style="background: #00D;">foo</p>',
+        ),
+        (
+            "<p style=\"background: url('topbanner.png') #00D;\">foo</p>",
+            '<p style="background: #00D;">foo</p>',
+        ),
+        (
+            "<p style='background: url(\"topbanner.png\") #00D;'>foo</p>",
+            '<p style="background: #00D;">foo</p>',
+        ),
+        # Verify urls with spacing
+        (
+            "<p style=\"background: url(  'topbanner.png') #00D;\">foo</p>",
+            '<p style="background: #00D;">foo</p>',
+        ),
+        (
+            "<p style=\"background: url('topbanner.png'  ) #00D;\">foo</p>",
+            '<p style="background: #00D;">foo</p>',
+        ),
+        (
+            "<p style=\"background: url(  'topbanner.png'  ) #00D;\">foo</p>",
+            '<p style="background: #00D;">foo</p>',
+        ),
+        (
+            "<p style=\"background: url (  'topbanner.png'  ) #00D;\">foo</p>",
+            '<p style="background: #00D;">foo</p>',
+        ),
+        # Verify urls with character entities
+        (
+            "<p style=\"background: url&#x09;('topbanner.png') #00D;\">foo</p>",
+            '<p style="background: #00D;">foo</p>',
+        ),
+    ],
+)
 def test_urls(data, expected):
-    assert clean(data, styles=['background']) == expected
+    assert clean(data, styles=["background"]) == expected
 
 
 def test_style_hang():
     """The sanitizer should not hang on any inline styles"""
     style = [
-        'margin-top: 0px;',
-        'margin-right: 0px;',
-        'margin-bottom: 1.286em;',
-        'margin-left: 0px;',
-        'padding-top: 15px;',
-        'padding-right: 15px;',
-        'padding-bottom: 15px;',
-        'padding-left: 15px;',
-        'border-top-width: 1px;',
-        'border-right-width: 1px;',
-        'border-bottom-width: 1px;',
-        'border-left-width: 1px;',
-        'border-top-style: dotted;',
-        'border-right-style: dotted;',
-        'border-bottom-style: dotted;',
-        'border-left-style: dotted;',
-        'border-top-color: rgb(203, 200, 185);',
-        'border-right-color: rgb(203, 200, 185);',
-        'border-bottom-color: rgb(203, 200, 185);',
-        'border-left-color: rgb(203, 200, 185);',
-        'background-image: initial;',
-        'background-attachment: initial;',
-        'background-origin: initial;',
-        'background-clip: initial;',
-        'background-color: rgb(246, 246, 242);',
-        'overflow-x: auto;',
-        'overflow-y: auto;',
-        'font: italic small-caps bolder condensed 16px/3 cursive;',
-        'background-position: initial initial;',
-        'background-repeat: initial initial;'
+        "margin-top: 0px;",
+        "margin-right: 0px;",
+        "margin-bottom: 1.286em;",
+        "margin-left: 0px;",
+        "padding-top: 15px;",
+        "padding-right: 15px;",
+        "padding-bottom: 15px;",
+        "padding-left: 15px;",
+        "border-top-width: 1px;",
+        "border-right-width: 1px;",
+        "border-bottom-width: 1px;",
+        "border-left-width: 1px;",
+        "border-top-style: dotted;",
+        "border-right-style: dotted;",
+        "border-bottom-style: dotted;",
+        "border-left-style: dotted;",
+        "border-top-color: rgb(203, 200, 185);",
+        "border-right-color: rgb(203, 200, 185);",
+        "border-bottom-color: rgb(203, 200, 185);",
+        "border-left-color: rgb(203, 200, 185);",
+        "background-image: initial;",
+        "background-attachment: initial;",
+        "background-origin: initial;",
+        "background-clip: initial;",
+        "background-color: rgb(246, 246, 242);",
+        "overflow-x: auto;",
+        "overflow-y: auto;",
+        "font: italic small-caps bolder condensed 16px/3 cursive;",
+        "background-position: initial initial;",
+        "background-repeat: initial initial;",
     ]
-    html = '<p style="%s">Hello world</p>' % ' '.join(style)
+    html = '<p style="%s">Hello world</p>' % " ".join(style)
     styles = [
-        'border', 'float', 'overflow', 'min-height', 'vertical-align',
-        'white-space',
-        'margin', 'margin-left', 'margin-top', 'margin-bottom', 'margin-right',
-        'padding', 'padding-left', 'padding-top', 'padding-bottom',
-        'padding-right',
-        'background',
-        'background-color',
-        'font', 'font-size', 'font-weight', 'text-align', 'text-transform',
+        "border",
+        "float",
+        "overflow",
+        "min-height",
+        "vertical-align",
+        "white-space",
+        "margin",
+        "margin-left",
+        "margin-top",
+        "margin-bottom",
+        "margin-right",
+        "padding",
+        "padding-left",
+        "padding-top",
+        "padding-bottom",
+        "padding-right",
+        "background",
+        "background-color",
+        "font",
+        "font-size",
+        "font-weight",
+        "text-align",
+        "text-transform",
     ]
 
     expected = (
         '<p style="'
-        'margin-top: 0px; '
-        'margin-right: 0px; '
-        'margin-bottom: 1.286em; '
-        'margin-left: 0px; '
-        'padding-top: 15px; '
-        'padding-right: 15px; '
-        'padding-bottom: 15px; '
-        'padding-left: 15px; '
-        'background-color: rgb(246, 246, 242); '
-        'font: italic small-caps bolder condensed 16px/3 cursive;'
+        "margin-top: 0px; "
+        "margin-right: 0px; "
+        "margin-bottom: 1.286em; "
+        "margin-left: 0px; "
+        "padding-top: 15px; "
+        "padding-right: 15px; "
+        "padding-bottom: 15px; "
+        "padding-left: 15px; "
+        "background-color: rgb(246, 246, 242); "
+        "font: italic small-caps bolder condensed 16px/3 cursive;"
         '">Hello world</p>'
     )
 
     assert clean(html, styles=styles) == expected
 
 
-@pytest.mark.parametrize('data, styles, expected', [
-    (
-        '<p style="font-family: Droid Sans, serif; white-space: pre-wrap;">text</p>',
-        ['font-family', 'white-space'],
-        '<p style="font-family: Droid Sans, serif; white-space: pre-wrap;">text</p>'
-    ),
-    (
-        '<p style="font-family: &quot;Droid Sans&quot;, serif; white-space: pre-wrap;">text</p>',
-        ['font-family', 'white-space'],
-        '<p style=\'font-family: "Droid Sans", serif; white-space: pre-wrap;\'>text</p>'
-    ),
-])
+@pytest.mark.parametrize(
+    "data, styles, expected",
+    [
+        (
+            '<p style="font-family: Droid Sans, serif; white-space: pre-wrap;">text</p>',
+            ["font-family", "white-space"],
+            '<p style="font-family: Droid Sans, serif; white-space: pre-wrap;">text</p>',
+        ),
+        (
+            '<p style="font-family: &quot;Droid Sans&quot;, serif; white-space: pre-wrap;">text</p>',
+            ["font-family", "white-space"],
+            "<p style='font-family: \"Droid Sans\", serif; white-space: pre-wrap;'>text</p>",
+        ),
+    ],
+)
 def test_css_parsing_with_entities(data, styles, expected):
     """The sanitizer should be ok with character entities"""
-    assert clean(data, tags=['p'], attributes={'p': ['style']}, styles=styles) == expected
+    assert (
+        clean(data, tags=["p"], attributes={"p": ["style"]}, styles=styles) == expected
+    )
 
 
-@pytest.mark.parametrize('overlap_test_char', ["\"", "'", "-"])
+@pytest.mark.parametrize("overlap_test_char", ['"', "'", "-"])
 def test_css_parsing_gauntlet_regex_backtracking(overlap_test_char):
     """The sanitizer gauntlet regex should not catastrophically backtrack"""
     # refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1623633
 
     def time_clean(test_char, size):
-        style_attr_value = (test_char + 'a' + test_char) * size + '^'
-        stmt = """clean('''<a style='%s'></a>''', attributes={'a': ['style']})""" % style_attr_value
-        return timeit(stmt=stmt, setup='from bleach import clean', number=1)
+        style_attr_value = (test_char + "a" + test_char) * size + "^"
+        stmt = (
+            """clean('''<a style='%s'></a>''', attributes={'a': ['style']})"""
+            % style_attr_value
+        )
+        return timeit(stmt=stmt, setup="from bleach import clean", number=1)
 
     # should complete in less than one second
     assert time_clean(overlap_test_char, 22) < 1.0

--- a/tests/test_html5lib_shim.py
+++ b/tests/test_html5lib_shim.py
@@ -5,71 +5,67 @@ import pytest
 from bleach import html5lib_shim
 
 
-@pytest.mark.parametrize('data, expected', [
-    # Strings without character entities pass through as is
-    ('', ''),
-    ('abc', 'abc'),
-
-    # Handles character entities--both named and numeric
-    ('&nbsp;', '\xa0'),
-    ('&#32;', ' '),
-    ('&#x20;', ' '),
-
-    # Handles ambiguous ampersand
-    ('&xx;', '&xx;'),
-
-    # Handles multiple entities in the same string
-    ('this &amp; that &amp; that', 'this & that & that'),
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # Strings without character entities pass through as is
+        ("", ""),
+        ("abc", "abc"),
+        # Handles character entities--both named and numeric
+        ("&nbsp;", "\xa0"),
+        ("&#32;", " "),
+        ("&#x20;", " "),
+        # Handles ambiguous ampersand
+        ("&xx;", "&xx;"),
+        # Handles multiple entities in the same string
+        ("this &amp; that &amp; that", "this & that & that"),
+    ],
+)
 def test_convert_entities(data, expected):
     assert html5lib_shim.convert_entities(data) == expected
 
 
-@pytest.mark.parametrize('data, expected', [
-    ('', ''),
-    ('text', 'text'),
-
-    # & in Characters is escaped
-    ('&', '&amp;'),
-
-    # FIXME(willkg): This happens because the BleachHTMLTokenizer is ignoring
-    # character entities. What it should be doing is creating Entity tokens
-    # for character entities.
-    #
-    # That was too hard at the time I was fixing it, so I fixed it in
-    # BleachSanitizerFilter. When that gest fixed correctly in the tokenizer,
-    # then this test cases will get fixed.
-    ('a &amp; b', 'a &amp;amp; b'),    # should be 'a &amp; b'
-
-    # & in HTML attribute values are escaped
-    (
-        '<a href="http://example.com?key=value&key2=value">tag</a>',
-        '<a href="http://example.com?key=value&amp;key2=value">tag</a>'
-    ),
-    # & marking character entities in HTML attribute values aren't escaped
-    (
-        '<a href="http://example.com?key=value&amp;key2=value">tag</a>',
-        '<a href="http://example.com?key=value&amp;key2=value">tag</a>'
-    ),
-    # & marking ambiguous character entities in attribute values are escaped
-    # (&curren; is a character entity)
-    (
-        '<a href="http://example.com?key=value&current=value">tag</a>',
-        '<a href="http://example.com?key=value&amp;current=value">tag</a>'
-    ),
-
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        ("", ""),
+        ("text", "text"),
+        # & in Characters is escaped
+        ("&", "&amp;"),
+        # FIXME(willkg): This happens because the BleachHTMLTokenizer is ignoring
+        # character entities. What it should be doing is creating Entity tokens
+        # for character entities.
+        #
+        # That was too hard at the time I was fixing it, so I fixed it in
+        # BleachSanitizerFilter. When that gest fixed correctly in the tokenizer,
+        # then this test cases will get fixed.
+        ("a &amp; b", "a &amp;amp; b"),  # should be 'a &amp; b'
+        # & in HTML attribute values are escaped
+        (
+            '<a href="http://example.com?key=value&key2=value">tag</a>',
+            '<a href="http://example.com?key=value&amp;key2=value">tag</a>',
+        ),
+        # & marking character entities in HTML attribute values aren't escaped
+        (
+            '<a href="http://example.com?key=value&amp;key2=value">tag</a>',
+            '<a href="http://example.com?key=value&amp;key2=value">tag</a>',
+        ),
+        # & marking ambiguous character entities in attribute values are escaped
+        # (&curren; is a character entity)
+        (
+            '<a href="http://example.com?key=value&current=value">tag</a>',
+            '<a href="http://example.com?key=value&amp;current=value">tag</a>',
+        ),
+    ],
+)
 def test_serializer(data, expected):
     # Build a parser, walker, and serializer just like we do in clean()
     parser = html5lib_shim.BleachHTMLParser(
-        tags=None,
-        strip=True,
-        consume_entities=False,
-        namespaceHTMLElements=False
+        tags=None, strip=True, consume_entities=False, namespaceHTMLElements=False
     )
-    walker = html5lib_shim.getTreeWalker('etree')
+    walker = html5lib_shim.getTreeWalker("etree")
     serializer = html5lib_shim.BleachHTMLSerializer(
-        quote_attr_values='always',
+        quote_attr_values="always",
         omit_optional_tags=False,
         escape_lt_in_attrs=True,
         resolve_entities=False,
@@ -84,60 +80,43 @@ def test_serializer(data, expected):
     assert serialized == expected
 
 
-@pytest.mark.parametrize('parser_args, data, expected', [
-    # Make sure InputStreamWithMemory has charEncoding and changeEncoding
-    (
-        {},
-        '<meta charset="utf-8">',
-        '<meta charset="utf-8">'
-    ),
-    # Handle consume entities False--all entities are passed along and then
-    # escaped when serialized
-    (
-        {'consume_entities': False},
-        'text &amp;&gt;&quot;',
-        'text &amp;amp;&amp;gt;&amp;quot;'
-    ),
-    # Handle consume entities True--all entities are consumed and converted
-    # to their character equivalents and then &, <, and > are escaped when
-    # serialized
-    (
-        {'consume_entities': True},
-        'text &amp;&gt;&quot;',
-        'text &amp;&gt;"'
-    ),
-    # Test that "invalid-character-in-attribute-name" errors in tokenizing
-    # result in attributes with invalid names getting dropped
-    (
-        {},
-        '<a href="http://example.com"">',
-        '<a href="http://example.com"></a>'
-    ),
-    (
-        {},
-        '<a href=\'http://example.com\'\'>',
-        '<a href="http://example.com"></a>'
-    ),
-    # Test that "expected-closing-tag-but-got-char" works when tags is None
-    (
-        {},
-        '</ chars',
-        '<!-- chars-->',
-    )
-])
+@pytest.mark.parametrize(
+    "parser_args, data, expected",
+    [
+        # Make sure InputStreamWithMemory has charEncoding and changeEncoding
+        ({}, '<meta charset="utf-8">', '<meta charset="utf-8">'),
+        # Handle consume entities False--all entities are passed along and then
+        # escaped when serialized
+        (
+            {"consume_entities": False},
+            "text &amp;&gt;&quot;",
+            "text &amp;amp;&amp;gt;&amp;quot;",
+        ),
+        # Handle consume entities True--all entities are consumed and converted
+        # to their character equivalents and then &, <, and > are escaped when
+        # serialized
+        ({"consume_entities": True}, "text &amp;&gt;&quot;", 'text &amp;&gt;"'),
+        # Test that "invalid-character-in-attribute-name" errors in tokenizing
+        # result in attributes with invalid names getting dropped
+        ({}, '<a href="http://example.com"">', '<a href="http://example.com"></a>'),
+        ({}, "<a href='http://example.com''>", '<a href="http://example.com"></a>'),
+        # Test that "expected-closing-tag-but-got-char" works when tags is None
+        (
+            {},
+            "</ chars",
+            "<!-- chars-->",
+        ),
+    ],
+)
 def test_bleach_html_parser(parser_args, data, expected):
-    args = {
-        'tags': None,
-        'strip': True,
-        'consume_entities': True
-    }
+    args = {"tags": None, "strip": True, "consume_entities": True}
     args.update(parser_args)
 
     # Build a parser, walker, and serializer just like we do in clean()
     parser = html5lib_shim.BleachHTMLParser(**args)
-    walker = html5lib_shim.getTreeWalker('etree')
+    walker = html5lib_shim.getTreeWalker("etree")
     serializer = html5lib_shim.BleachHTMLSerializer(
-        quote_attr_values='always',
+        quote_attr_values="always",
         omit_optional_tags=False,
         escape_lt_in_attrs=True,
         resolve_entities=False,

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -11,50 +11,51 @@ from bleach.sanitizer import Cleaner
 
 
 def test_empty():
-    assert linkify('') == ''
+    assert linkify("") == ""
 
 
 def test_simple_link():
     assert (
-        linkify('a http://example.com link') ==
-        'a <a href="http://example.com" rel="nofollow">http://example.com</a> link'
+        linkify("a http://example.com link")
+        == 'a <a href="http://example.com" rel="nofollow">http://example.com</a> link'
     )
     assert (
-        linkify('a https://example.com link') ==
-        'a <a href="https://example.com" rel="nofollow">https://example.com</a> link'
+        linkify("a https://example.com link")
+        == 'a <a href="https://example.com" rel="nofollow">https://example.com</a> link'
     )
     assert (
-        linkify('a example.com link') ==
-        'a <a href="http://example.com" rel="nofollow">example.com</a> link'
+        linkify("a example.com link")
+        == 'a <a href="http://example.com" rel="nofollow">example.com</a> link'
     )
 
 
 def test_trailing_slash():
     assert (
-        linkify('http://examp.com/') ==
-        '<a href="http://examp.com/" rel="nofollow">http://examp.com/</a>'
+        linkify("http://examp.com/")
+        == '<a href="http://examp.com/" rel="nofollow">http://examp.com/</a>'
     )
     assert (
-        linkify('http://example.com/foo/') ==
-        '<a href="http://example.com/foo/" rel="nofollow">http://example.com/foo/</a>'
+        linkify("http://example.com/foo/")
+        == '<a href="http://example.com/foo/" rel="nofollow">http://example.com/foo/</a>'
     )
     assert (
-        linkify('http://example.com/foo/bar/') ==
-        '<a href="http://example.com/foo/bar/" rel="nofollow">http://example.com/foo/bar/</a>'
+        linkify("http://example.com/foo/bar/")
+        == '<a href="http://example.com/foo/bar/" rel="nofollow">http://example.com/foo/bar/</a>'
     )
 
 
 def test_mangle_link():
     """We can muck with the href attribute of the link."""
+
     def filter_url(attrs, new=False):
-        if not attrs.get((None, 'href'), '').startswith('http://bouncer'):
-            quoted = quote_plus(attrs[(None, 'href')])
-            attrs[(None, 'href')] = 'http://bouncer/?u={0!s}'.format(quoted)
+        if not attrs.get((None, "href"), "").startswith("http://bouncer"):
+            quoted = quote_plus(attrs[(None, "href")])
+            attrs[(None, "href")] = "http://bouncer/?u={0!s}".format(quoted)
         return attrs
 
     assert (
-        linkify('http://example.com', callbacks=DC + [filter_url]) ==
-        '<a href="http://bouncer/?u=http%3A%2F%2Fexample.com" rel="nofollow">http://example.com</a>'
+        linkify("http://example.com", callbacks=DC + [filter_url])
+        == '<a href="http://bouncer/?u=http%3A%2F%2Fexample.com" rel="nofollow">http://example.com</a>'
     )
 
 
@@ -62,79 +63,72 @@ def test_mangle_text():
     """We can muck with the inner text of a link."""
 
     def ft(attrs, new=False):
-        attrs['_text'] = 'bar'
+        attrs["_text"] = "bar"
         return attrs
 
     assert (
-        linkify('http://ex.mp <a href="http://ex.mp/foo">foo</a>', callbacks=[ft]) ==
-        '<a href="http://ex.mp">bar</a> <a href="http://ex.mp/foo">bar</a>'
+        linkify('http://ex.mp <a href="http://ex.mp/foo">foo</a>', callbacks=[ft])
+        == '<a href="http://ex.mp">bar</a> <a href="http://ex.mp/foo">bar</a>'
     )
 
 
-@pytest.mark.parametrize('data,parse_email,expected', [
-    (
-        'a james@example.com mailto',
-        False,
-        'a james@example.com mailto'
-    ),
-    (
-        'a james@example.com.au mailto',
-        False,
-        'a james@example.com.au mailto'
-    ),
-    (
-        'a james@example.com mailto',
-        True,
-        'a <a href="mailto:james@example.com">james@example.com</a> mailto'
-    ),
-    (
-        'aussie james@example.com.au mailto',
-        True,
-        'aussie <a href="mailto:james@example.com.au">james@example.com.au</a> mailto'
-    ),
-    # This is kind of a pathological case. I guess we do our best here.
-    (
-        'email to <a href="james@example.com">james@example.com</a>',
-        True,
-        'email to <a href="james@example.com" rel="nofollow">james@example.com</a>'
-    ),
-    (
-        '<br>jinkyun@example.com',
-        True,
-        '<br><a href="mailto:jinkyun@example.com">jinkyun@example.com</a>'
-    ),
-    # Mailto links at the end of a sentence.
-    (
-        'mailto james@example.com.au.',
-        True,
-        'mailto <a href="mailto:james@example.com.au">james@example.com.au</a>.'
-    ),
-    # Incorrect email
-    (
-        '"\\\n"@opa.ru',
-        True,
-        '"\\\n"@opa.ru'
-    ),
-
-])
+@pytest.mark.parametrize(
+    "data,parse_email,expected",
+    [
+        ("a james@example.com mailto", False, "a james@example.com mailto"),
+        ("a james@example.com.au mailto", False, "a james@example.com.au mailto"),
+        (
+            "a james@example.com mailto",
+            True,
+            'a <a href="mailto:james@example.com">james@example.com</a> mailto',
+        ),
+        (
+            "aussie james@example.com.au mailto",
+            True,
+            'aussie <a href="mailto:james@example.com.au">james@example.com.au</a> mailto',
+        ),
+        # This is kind of a pathological case. I guess we do our best here.
+        (
+            'email to <a href="james@example.com">james@example.com</a>',
+            True,
+            'email to <a href="james@example.com" rel="nofollow">james@example.com</a>',
+        ),
+        (
+            "<br>jinkyun@example.com",
+            True,
+            '<br><a href="mailto:jinkyun@example.com">jinkyun@example.com</a>',
+        ),
+        # Mailto links at the end of a sentence.
+        (
+            "mailto james@example.com.au.",
+            True,
+            'mailto <a href="mailto:james@example.com.au">james@example.com.au</a>.',
+        ),
+        # Incorrect email
+        ('"\\\n"@opa.ru', True, '"\\\n"@opa.ru'),
+    ],
+)
 def test_email_link(data, parse_email, expected):
     assert linkify(data, parse_email=parse_email) == expected
 
 
-@pytest.mark.parametrize('data, expected', [
-    (
-        '"james"@example.com',
-        '''<a href='mailto:"james"@example.com'>"james"@example.com</a>'''
-    ),
-    (
-        '"j\'ames"@example.com',
-        '''<a href="mailto:&quot;j'ames&quot;@example.com">"j'ames"@example.com</a>'''
-    ),
-    (
-        '"ja>mes"@example.com',
-        '''<a href='mailto:"ja>mes"@example.com'>"ja&gt;mes"@example.com</a>'''
-    ),
-])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            '"james"@example.com',
+            """<a href='mailto:"james"@example.com'>"james"@example.com</a>""",
+        ),
+        (
+            '"j\'ames"@example.com',
+            """<a href="mailto:&quot;j'ames&quot;@example.com">"j'ames"@example.com</a>""",
+        ),
+        (
+            '"ja>mes"@example.com',
+            """<a href='mailto:"ja>mes"@example.com'>"ja&gt;mes"@example.com</a>""",
+        ),
+    ],
+)
 def test_email_link_escaping(data, expected):
     assert linkify(data, parse_email=True) == expected
 
@@ -155,32 +149,20 @@ def noop(attrs, new=False):
     return attrs
 
 
-@pytest.mark.parametrize('callback,expected', [
-    (
-        [noop],
-        'a <a href="http://ex.mp">ex.mp</a> <a href="http://example.com">example</a>'
-    ),
-    (
-        [no_new_links, noop],
-        'a ex.mp <a href="http://example.com">example</a>'
-    ),
-    (
-        [noop, no_new_links],
-        'a ex.mp <a href="http://example.com">example</a>'
-    ),
-    (
-        [no_old_links, noop],
-        'a <a href="http://ex.mp">ex.mp</a> example'
-    ),
-    (
-        [noop, no_old_links],
-        'a <a href="http://ex.mp">ex.mp</a> example'
-    ),
-    (
-        [no_old_links, no_new_links],
-        'a ex.mp example'
-    )
-])
+@pytest.mark.parametrize(
+    "callback,expected",
+    [
+        (
+            [noop],
+            'a <a href="http://ex.mp">ex.mp</a> <a href="http://example.com">example</a>',
+        ),
+        ([no_new_links, noop], 'a ex.mp <a href="http://example.com">example</a>'),
+        ([noop, no_new_links], 'a ex.mp <a href="http://example.com">example</a>'),
+        ([no_old_links, noop], 'a <a href="http://ex.mp">ex.mp</a> example'),
+        ([noop, no_old_links], 'a <a href="http://ex.mp">ex.mp</a> example'),
+        ([no_old_links, no_new_links], "a ex.mp example"),
+    ],
+)
 def test_prevent_links(callback, expected):
     """Returning None from any callback should remove links or prevent them
     from being created."""
@@ -192,212 +174,230 @@ def test_set_attrs():
     """We can set random attributes on links."""
 
     def set_attr(attrs, new=False):
-        attrs[(None, 'rev')] = 'canonical'
+        attrs[(None, "rev")] = "canonical"
         return attrs
 
     assert (
-        linkify('ex.mp', callbacks=[set_attr]) ==
-        '<a href="http://ex.mp" rev="canonical">ex.mp</a>'
+        linkify("ex.mp", callbacks=[set_attr])
+        == '<a href="http://ex.mp" rev="canonical">ex.mp</a>'
     )
 
 
 def test_only_proto_links():
     """Only create links if there's a protocol."""
+
     def only_proto(attrs, new=False):
-        if new and not attrs['_text'].startswith(('http:', 'https:')):
+        if new and not attrs["_text"].startswith(("http:", "https:")):
             return None
         return attrs
 
     in_text = 'a ex.mp http://ex.mp <a href="/foo">bar</a>'
     assert (
-        linkify(in_text, callbacks=[only_proto]) ==
-        'a ex.mp <a href="http://ex.mp">http://ex.mp</a> <a href="/foo">bar</a>'
+        linkify(in_text, callbacks=[only_proto])
+        == 'a ex.mp <a href="http://ex.mp">http://ex.mp</a> <a href="/foo">bar</a>'
     )
 
 
 def test_stop_email():
     """Returning None should prevent a link from being created."""
+
     def no_email(attrs, new=False):
-        if attrs[(None, 'href')].startswith('mailto:'):
+        if attrs[(None, "href")].startswith("mailto:"):
             return None
         return attrs
-    text = 'do not link james@example.com'
+
+    text = "do not link james@example.com"
 
     assert linkify(text, parse_email=True, callbacks=[no_email]) == text
 
 
-@pytest.mark.parametrize('data,expected', [
-    # tlds
-    ('example.com', '<a href="http://example.com" rel="nofollow">example.com</a>'),
-    ('example.co', '<a href="http://example.co" rel="nofollow">example.co</a>'),
-    ('example.co.uk', '<a href="http://example.co.uk" rel="nofollow">example.co.uk</a>'),
-    ('example.edu', '<a href="http://example.edu" rel="nofollow">example.edu</a>'),
-    ('example.xxx', '<a href="http://example.xxx" rel="nofollow">example.xxx</a>'),
-    ('bit.ly/fun', '<a href="http://bit.ly/fun" rel="nofollow">bit.ly/fun</a>'),
-
-    # non-tlds
-    ('example.yyy', 'example.yyy'),
-    ('brie', 'brie'),
-])
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        # tlds
+        ("example.com", '<a href="http://example.com" rel="nofollow">example.com</a>'),
+        ("example.co", '<a href="http://example.co" rel="nofollow">example.co</a>'),
+        (
+            "example.co.uk",
+            '<a href="http://example.co.uk" rel="nofollow">example.co.uk</a>',
+        ),
+        ("example.edu", '<a href="http://example.edu" rel="nofollow">example.edu</a>'),
+        ("example.xxx", '<a href="http://example.xxx" rel="nofollow">example.xxx</a>'),
+        ("bit.ly/fun", '<a href="http://bit.ly/fun" rel="nofollow">bit.ly/fun</a>'),
+        # non-tlds
+        ("example.yyy", "example.yyy"),
+        ("brie", "brie"),
+    ],
+)
 def test_tlds(data, expected):
     assert linkify(data) == expected
 
 
 def test_escaping():
-    assert linkify('< unrelated') == '&lt; unrelated'
+    assert linkify("< unrelated") == "&lt; unrelated"
 
 
 def test_nofollow_off():
-    assert linkify('example.com', callbacks=[]) == '<a href="http://example.com">example.com</a>'
+    assert (
+        linkify("example.com", callbacks=[])
+        == '<a href="http://example.com">example.com</a>'
+    )
 
 
 def test_link_in_html():
     assert (
-        linkify('<i>http://yy.com</i>') ==
-        '<i><a href="http://yy.com" rel="nofollow">http://yy.com</a></i>'
+        linkify("<i>http://yy.com</i>")
+        == '<i><a href="http://yy.com" rel="nofollow">http://yy.com</a></i>'
     )
     assert (
-        linkify('<em><strong>http://xx.com</strong></em>') ==
-        '<em><strong><a href="http://xx.com" rel="nofollow">http://xx.com</a></strong></em>'
+        linkify("<em><strong>http://xx.com</strong></em>")
+        == '<em><strong><a href="http://xx.com" rel="nofollow">http://xx.com</a></strong></em>'
     )
 
 
 def test_links_https():
     assert (
-        linkify('https://yy.com') ==
-        '<a href="https://yy.com" rel="nofollow">https://yy.com</a>'
+        linkify("https://yy.com")
+        == '<a href="https://yy.com" rel="nofollow">https://yy.com</a>'
     )
 
 
 def test_add_rel_nofollow():
     """Verify that rel="nofollow" is added to an existing link"""
     assert (
-        linkify('<a href="http://yy.com">http://yy.com</a>') ==
-        '<a href="http://yy.com" rel="nofollow">http://yy.com</a>'
+        linkify('<a href="http://yy.com">http://yy.com</a>')
+        == '<a href="http://yy.com" rel="nofollow">http://yy.com</a>'
     )
 
 
 def test_url_with_path():
     assert (
-        linkify('http://example.com/path/to/file') ==
-        '<a href="http://example.com/path/to/file" rel="nofollow">'
-        'http://example.com/path/to/file</a>'
+        linkify("http://example.com/path/to/file")
+        == '<a href="http://example.com/path/to/file" rel="nofollow">'
+        "http://example.com/path/to/file</a>"
     )
 
 
 def test_link_ftp():
     assert (
-        linkify('ftp://ftp.mozilla.org/some/file') ==
-        '<a href="ftp://ftp.mozilla.org/some/file" rel="nofollow">'
-        'ftp://ftp.mozilla.org/some/file</a>'
+        linkify("ftp://ftp.mozilla.org/some/file")
+        == '<a href="ftp://ftp.mozilla.org/some/file" rel="nofollow">'
+        "ftp://ftp.mozilla.org/some/file</a>"
     )
 
 
 def test_link_query():
     assert (
-        linkify('http://xx.com/?test=win') ==
-        '<a href="http://xx.com/?test=win" rel="nofollow">http://xx.com/?test=win</a>'
+        linkify("http://xx.com/?test=win")
+        == '<a href="http://xx.com/?test=win" rel="nofollow">http://xx.com/?test=win</a>'
     )
     assert (
-        linkify('xx.com/?test=win') ==
-        '<a href="http://xx.com/?test=win" rel="nofollow">xx.com/?test=win</a>'
+        linkify("xx.com/?test=win")
+        == '<a href="http://xx.com/?test=win" rel="nofollow">xx.com/?test=win</a>'
     )
     assert (
-        linkify('xx.com?test=win') ==
-        '<a href="http://xx.com?test=win" rel="nofollow">xx.com?test=win</a>'
+        linkify("xx.com?test=win")
+        == '<a href="http://xx.com?test=win" rel="nofollow">xx.com?test=win</a>'
     )
 
 
 def test_link_fragment():
     assert (
-        linkify('http://xx.com/path#frag') ==
-        '<a href="http://xx.com/path#frag" rel="nofollow">http://xx.com/path#frag</a>'
+        linkify("http://xx.com/path#frag")
+        == '<a href="http://xx.com/path#frag" rel="nofollow">http://xx.com/path#frag</a>'
     )
 
 
 def test_link_entities():
     assert (
-        linkify('http://xx.com/?a=1&b=2') ==
-        '<a href="http://xx.com/?a=1&amp;b=2" rel="nofollow">http://xx.com/?a=1&amp;b=2</a>'
+        linkify("http://xx.com/?a=1&b=2")
+        == '<a href="http://xx.com/?a=1&amp;b=2" rel="nofollow">http://xx.com/?a=1&amp;b=2</a>'
     )
 
 
 def test_escaped_html():
     """If I pass in escaped HTML, it should probably come out escaped."""
-    s = '&lt;em&gt;strong&lt;/em&gt;'
+    s = "&lt;em&gt;strong&lt;/em&gt;"
     assert linkify(s) == s
 
 
 def test_link_http_complete():
     assert (
-        linkify('https://user:pass@ftp.mozilla.org/x/y.exe?a=b&c=d&e#f') ==
-        '<a href="https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d&amp;e#f" rel="nofollow">'
-        'https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d&amp;e#f</a>'
+        linkify("https://user:pass@ftp.mozilla.org/x/y.exe?a=b&c=d&e#f")
+        == '<a href="https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d&amp;e#f" rel="nofollow">'
+        "https://user:pass@ftp.mozilla.org/x/y.exe?a=b&amp;c=d&amp;e#f</a>"
     )
 
 
 def test_non_url():
     """document.vulnerable should absolutely not be linkified."""
-    s = 'document.vulnerable'
+    s = "document.vulnerable"
     assert linkify(s) == s
 
 
 def test_javascript_url():
     """javascript: urls should never be linkified."""
-    s = 'javascript:document.vulnerable'
+    s = "javascript:document.vulnerable"
     assert linkify(s) == s
 
 
 def test_unsafe_url():
     """Any unsafe char ({}[]<>, etc.) in the path should end URL scanning."""
     assert (
-        linkify('All your{"xx.yy.com/grover.png"}base are') ==
-        'All your{"<a href="http://xx.yy.com/grover.png" rel="nofollow">xx.yy.com/grover.png</a>"}'
-        'base are'
+        linkify('All your{"xx.yy.com/grover.png"}base are')
+        == 'All your{"<a href="http://xx.yy.com/grover.png" rel="nofollow">xx.yy.com/grover.png</a>"}'
+        "base are"
     )
 
 
 def test_skip_tags():
     """Skip linkification in skip tags"""
-    simple = 'http://xx.com <pre>http://xx.com</pre>'
-    linked = ('<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
-              '<pre>http://xx.com</pre>')
-    all_linked = ('<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
-                  '<pre><a href="http://xx.com" rel="nofollow">http://xx.com'
-                  '</a></pre>')
-    assert linkify(simple, skip_tags=['pre']) == linked
+    simple = "http://xx.com <pre>http://xx.com</pre>"
+    linked = (
+        '<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
+        "<pre>http://xx.com</pre>"
+    )
+    all_linked = (
+        '<a href="http://xx.com" rel="nofollow">http://xx.com</a> '
+        '<pre><a href="http://xx.com" rel="nofollow">http://xx.com'
+        "</a></pre>"
+    )
+    assert linkify(simple, skip_tags=["pre"]) == linked
     assert linkify(simple) == all_linked
 
     already_linked = '<pre><a href="http://xx.com">xx</a></pre>'
     nofollowed = '<pre><a href="http://xx.com" rel="nofollow">xx</a></pre>'
     assert linkify(already_linked) == nofollowed
-    assert linkify(already_linked, skip_tags=['pre']) == nofollowed
+    assert linkify(already_linked, skip_tags=["pre"]) == nofollowed
 
-    assert (
-        linkify('<pre><code>http://example.com</code></pre>http://example.com', skip_tags=['pre']) ==
-        (
-            '<pre><code>http://example.com</code></pre>'
-            '<a href="http://example.com" rel="nofollow">http://example.com</a>'
-        )
+    assert linkify(
+        "<pre><code>http://example.com</code></pre>http://example.com",
+        skip_tags=["pre"],
+    ) == (
+        "<pre><code>http://example.com</code></pre>"
+        '<a href="http://example.com" rel="nofollow">http://example.com</a>'
     )
 
 
 def test_libgl():
     """libgl.so.1 should not be linkified."""
-    s = 'libgl.so.1'
+    s = "libgl.so.1"
     assert linkify(s) == s
 
 
-@pytest.mark.parametrize('url,periods', [
-    ('example.com', '.'),
-    ('example.com', '...'),
-    ('ex.com/foo', '.'),
-    ('ex.com/foo', '....'),
-])
+@pytest.mark.parametrize(
+    "url,periods",
+    [
+        ("example.com", "."),
+        ("example.com", "..."),
+        ("ex.com/foo", "."),
+        ("ex.com/foo", "...."),
+    ],
+)
 def test_end_of_sentence(url, periods):
     """example.com. should match."""
     out = '<a href="http://{0!s}" rel="nofollow">{0!s}</a>{1!s}'
-    intxt = '{0!s}{1!s}'
+    intxt = "{0!s}{1!s}"
 
     assert linkify(intxt.format(url, periods)) == out.format(url, periods)
 
@@ -405,79 +405,92 @@ def test_end_of_sentence(url, periods):
 def test_end_of_clause():
     """example.com/foo, shouldn't include the ,"""
     assert (
-        linkify('ex.com/foo, bar') ==
-        '<a href="http://ex.com/foo" rel="nofollow">ex.com/foo</a>, bar'
+        linkify("ex.com/foo, bar")
+        == '<a href="http://ex.com/foo" rel="nofollow">ex.com/foo</a>, bar'
     )
 
 
 def test_sarcasm():
     """Jokes should crash.<sarcasm/>"""
-    assert linkify('Yeah right <sarcasm/>') == 'Yeah right &lt;sarcasm/&gt;'
+    assert linkify("Yeah right <sarcasm/>") == "Yeah right &lt;sarcasm/&gt;"
 
 
-@pytest.mark.parametrize('data,expected_data', [
-    (
-        '(example.com)',
-        ('(', 'example.com', 'example.com', ')')
-    ),
-    (
-        '(example.com/)',
-        ('(', 'example.com/', 'example.com/', ')')
-    ),
-    (
-        '(example.com/foo)',
-        ('(', 'example.com/foo', 'example.com/foo', ')')
-    ),
-    (
-        '(((example.com/))))',
-        ('(((', 'example.com/', 'example.com/', '))))')
-    ),
-    (
-        'example.com/))',
-        ('', 'example.com/', 'example.com/', '))')
-    ),
-    (
-        '(foo http://example.com/)',
-        ('(foo ', 'example.com/', 'http://example.com/', ')')
-    ),
-    (
-        '(foo http://example.com)',
-        ('(foo ', 'example.com', 'http://example.com', ')')
-    ),
-    (
-        'http://en.wikipedia.org/wiki/Test_(assessment)',
-        ('', 'en.wikipedia.org/wiki/Test_(assessment)',
-         'http://en.wikipedia.org/wiki/Test_(assessment)', '')
-    ),
-    (
-        '(http://en.wikipedia.org/wiki/Test_(assessment))',
-        ('(', 'en.wikipedia.org/wiki/Test_(assessment)',
-         'http://en.wikipedia.org/wiki/Test_(assessment)', ')')
-    ),
-    (
-        '((http://en.wikipedia.org/wiki/Test_(assessment))',
-        ('((', 'en.wikipedia.org/wiki/Test_(assessment',
-         'http://en.wikipedia.org/wiki/Test_(assessment', '))')
-    ),
-    (
-        '(http://en.wikipedia.org/wiki/Test_(assessment)))',
-        ('(', 'en.wikipedia.org/wiki/Test_(assessment))',
-         'http://en.wikipedia.org/wiki/Test_(assessment))', ')')
-    ),
-    (
-        '(http://en.wikipedia.org/wiki/)Test_(assessment',
-        ('(', 'en.wikipedia.org/wiki/)Test_(assessment',
-         'http://en.wikipedia.org/wiki/)Test_(assessment', '')
-    ),
-    (
-        'hello (http://www.mu.de/blah.html) world',
-        ('hello (', 'www.mu.de/blah.html', 'http://www.mu.de/blah.html', ') world')
-    ),
-    (
-        'hello (http://www.mu.de/blah.html). world',
-        ('hello (', 'www.mu.de/blah.html', 'http://www.mu.de/blah.html', '). world')
-    )
-])
+@pytest.mark.parametrize(
+    "data,expected_data",
+    [
+        ("(example.com)", ("(", "example.com", "example.com", ")")),
+        ("(example.com/)", ("(", "example.com/", "example.com/", ")")),
+        ("(example.com/foo)", ("(", "example.com/foo", "example.com/foo", ")")),
+        ("(((example.com/))))", ("(((", "example.com/", "example.com/", "))))")),
+        ("example.com/))", ("", "example.com/", "example.com/", "))")),
+        (
+            "(foo http://example.com/)",
+            ("(foo ", "example.com/", "http://example.com/", ")"),
+        ),
+        (
+            "(foo http://example.com)",
+            ("(foo ", "example.com", "http://example.com", ")"),
+        ),
+        (
+            "http://en.wikipedia.org/wiki/Test_(assessment)",
+            (
+                "",
+                "en.wikipedia.org/wiki/Test_(assessment)",
+                "http://en.wikipedia.org/wiki/Test_(assessment)",
+                "",
+            ),
+        ),
+        (
+            "(http://en.wikipedia.org/wiki/Test_(assessment))",
+            (
+                "(",
+                "en.wikipedia.org/wiki/Test_(assessment)",
+                "http://en.wikipedia.org/wiki/Test_(assessment)",
+                ")",
+            ),
+        ),
+        (
+            "((http://en.wikipedia.org/wiki/Test_(assessment))",
+            (
+                "((",
+                "en.wikipedia.org/wiki/Test_(assessment",
+                "http://en.wikipedia.org/wiki/Test_(assessment",
+                "))",
+            ),
+        ),
+        (
+            "(http://en.wikipedia.org/wiki/Test_(assessment)))",
+            (
+                "(",
+                "en.wikipedia.org/wiki/Test_(assessment))",
+                "http://en.wikipedia.org/wiki/Test_(assessment))",
+                ")",
+            ),
+        ),
+        (
+            "(http://en.wikipedia.org/wiki/)Test_(assessment",
+            (
+                "(",
+                "en.wikipedia.org/wiki/)Test_(assessment",
+                "http://en.wikipedia.org/wiki/)Test_(assessment",
+                "",
+            ),
+        ),
+        (
+            "hello (http://www.mu.de/blah.html) world",
+            ("hello (", "www.mu.de/blah.html", "http://www.mu.de/blah.html", ") world"),
+        ),
+        (
+            "hello (http://www.mu.de/blah.html). world",
+            (
+                "hello (",
+                "www.mu.de/blah.html",
+                "http://www.mu.de/blah.html",
+                "). world",
+            ),
+        ),
+    ],
+)
 def test_wrapping_parentheses(data, expected_data):
     """URLs wrapped in parantheses should not include them."""
     out = '{0!s}<a href="http://{1!s}" rel="nofollow">{2!s}</a>{3!s}'
@@ -486,24 +499,28 @@ def test_wrapping_parentheses(data, expected_data):
 
 
 def test_parentheses_with_removing():
-    expected = '(test.py)'
+    expected = "(test.py)"
     assert linkify(expected, callbacks=[lambda *a: None]) == expected
 
 
-@pytest.mark.parametrize('data,expected_data', [
-    # Test valid ports
-    ('http://foo.com:8000', ('http://foo.com:8000', '')),
-    ('http://foo.com:8000/', ('http://foo.com:8000/', '')),
-
-    # Test non ports
-    ('http://bar.com:xkcd', ('http://bar.com', ':xkcd')),
-    ('http://foo.com:81/bar', ('http://foo.com:81/bar', '')),
-    ('http://foo.com:', ('http://foo.com', ':')),
-
-    # Test non-ascii ports
-    ('http://foo.com:\u0663\u0669/', ('http://foo.com', ':\u0663\u0669/')),
-    ('http://foo.com:\U0001d7e0\U0001d7d8/', ('http://foo.com', ':\U0001d7e0\U0001d7d8/')),
-])
+@pytest.mark.parametrize(
+    "data,expected_data",
+    [
+        # Test valid ports
+        ("http://foo.com:8000", ("http://foo.com:8000", "")),
+        ("http://foo.com:8000/", ("http://foo.com:8000/", "")),
+        # Test non ports
+        ("http://bar.com:xkcd", ("http://bar.com", ":xkcd")),
+        ("http://foo.com:81/bar", ("http://foo.com:81/bar", "")),
+        ("http://foo.com:", ("http://foo.com", ":")),
+        # Test non-ascii ports
+        ("http://foo.com:\u0663\u0669/", ("http://foo.com", ":\u0663\u0669/")),
+        (
+            "http://foo.com:\U0001d7e0\U0001d7d8/",
+            ("http://foo.com", ":\U0001d7e0\U0001d7d8/"),
+        ),
+    ],
+)
 def test_ports(data, expected_data):
     """URLs can contain port numbers."""
     out = '<a href="{0}" rel="nofollow">{0}</a>{1}'
@@ -511,43 +528,37 @@ def test_ports(data, expected_data):
 
 
 def test_ignore_bad_protocols():
+    assert linkify("foohttp://bar") == "foohttp://bar"
     assert (
-        linkify('foohttp://bar') ==
-        'foohttp://bar'
-    )
-    assert (
-        linkify('fohttp://exampl.com') ==
-        'fohttp://<a href="http://exampl.com" rel="nofollow">exampl.com</a>'
+        linkify("fohttp://exampl.com")
+        == 'fohttp://<a href="http://exampl.com" rel="nofollow">exampl.com</a>'
     )
 
 
 def test_link_emails_and_urls():
     """parse_email=True shouldn't prevent URLs from getting linkified."""
-    assert (
-        linkify('http://example.com person@example.com', parse_email=True) ==
-        (
-            '<a href="http://example.com" rel="nofollow">'
-            'http://example.com</a> <a href="mailto:person@example.com">'
-            'person@example.com</a>'
-        )
+    assert linkify("http://example.com person@example.com", parse_email=True) == (
+        '<a href="http://example.com" rel="nofollow">'
+        'http://example.com</a> <a href="mailto:person@example.com">'
+        "person@example.com</a>"
     )
 
 
 def test_links_case_insensitive():
     """Protocols and domain names are case insensitive."""
     expect = '<a href="HTTP://EXAMPLE.COM" rel="nofollow">HTTP://EXAMPLE.COM</a>'
-    assert linkify('HTTP://EXAMPLE.COM') == expect
+    assert linkify("HTTP://EXAMPLE.COM") == expect
 
 
 def test_elements_inside_links():
     assert (
-        linkify('<a href="#">hello<br></a>') ==
-        '<a href="#" rel="nofollow">hello<br></a>'
+        linkify('<a href="#">hello<br></a>')
+        == '<a href="#" rel="nofollow">hello<br></a>'
     )
 
     assert (
-        linkify('<a href="#"><strong>bold</strong> hello<br></a>') ==
-        '<a href="#" rel="nofollow"><strong>bold</strong> hello<br></a>'
+        linkify('<a href="#"><strong>bold</strong> hello<br></a>')
+        == '<a href="#" rel="nofollow"><strong>bold</strong> hello<br></a>'
     )
 
 
@@ -555,25 +566,28 @@ def test_drop_link_tags():
     """Verify that dropping link tags *just* drops the tag and not the content"""
     html = (
         'first <a href="http://example.com/1/">second</a> third <a href="http://example.com/2/">'
-        'fourth</a> fifth'
+        "fourth</a> fifth"
     )
     assert (
-        linkify(html, callbacks=[lambda attrs, new: None]) ==
-        'first second third fourth fifth'
+        linkify(html, callbacks=[lambda attrs, new: None])
+        == "first second third fourth fifth"
     )
 
 
-@pytest.mark.parametrize('text, expected', [
-    ('&lt;br&gt;', '&lt;br&gt;'),
-    (
-        '&lt;br&gt; http://example.com',
-        '&lt;br&gt; <a href="http://example.com" rel="nofollow">http://example.com</a>'
-    ),
-    (
-        '&lt;br&gt; <br> http://example.com',
-        '&lt;br&gt; <br> <a href="http://example.com" rel="nofollow">http://example.com</a>'
-    )
-])
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("&lt;br&gt;", "&lt;br&gt;"),
+        (
+            "&lt;br&gt; http://example.com",
+            '&lt;br&gt; <a href="http://example.com" rel="nofollow">http://example.com</a>',
+        ),
+        (
+            "&lt;br&gt; <br> http://example.com",
+            '&lt;br&gt; <br> <a href="http://example.com" rel="nofollow">http://example.com</a>',
+        ),
+    ],
+)
 def test_naughty_unescaping(text, expected):
     """Verify that linkify is not unescaping things it shouldn't be"""
     assert linkify(text) == expected
@@ -582,16 +596,16 @@ def test_naughty_unescaping(text, expected):
 def test_hang():
     """This string would hang linkify. Issue #200"""
     assert (
-        linkify("an@email.com<mailto:an@email.com>", parse_email=True) ==
-        '<a href="mailto:an@email.com">an@email.com</a>&lt;mailto:<a href="mailto:an@email.com">an@email.com</a>&gt;'  # noqa
+        linkify("an@email.com<mailto:an@email.com>", parse_email=True)
+        == '<a href="mailto:an@email.com">an@email.com</a>&lt;mailto:<a href="mailto:an@email.com">an@email.com</a>&gt;'  # noqa
     )
 
 
 def test_hyphen_in_mail():
     """Test hyphens `-` in mails. Issue #300."""
     assert (
-        linkify('ex@am-ple.com', parse_email=True) ==
-        '<a href="mailto:ex@am-ple.com">ex@am-ple.com</a>'
+        linkify("ex@am-ple.com", parse_email=True)
+        == '<a href="mailto:ex@am-ple.com">ex@am-ple.com</a>'
     )
 
 
@@ -601,13 +615,13 @@ def test_url_re_arg():
 
     linker = Linker(url_re=fred_re)
     assert (
-        linker.linkify('a b c fred.com d e f') ==
-        'a b c <a href="http://fred.com" rel="nofollow">fred.com</a> d e f'
+        linker.linkify("a b c fred.com d e f")
+        == 'a b c <a href="http://fred.com" rel="nofollow">fred.com</a> d e f'
     )
 
     assert (
-        linker.linkify('a b c http://example.com d e f') ==
-        'a b c http://example.com d e f'
+        linker.linkify("a b c http://example.com d e f")
+        == "a b c http://example.com d e f"
     )
 
 
@@ -617,35 +631,34 @@ def test_email_re_arg():
 
     linker = Linker(parse_email=True, email_re=fred_re)
     assert (
-        linker.linkify('a b c fred@example.com d e f') ==
-        'a b c <a href="mailto:fred@example.com">fred@example.com</a> d e f'
+        linker.linkify("a b c fred@example.com d e f")
+        == 'a b c <a href="mailto:fred@example.com">fred@example.com</a> d e f'
     )
 
     assert (
-        linker.linkify('a b c jim@example.com d e f') ==
-        'a b c jim@example.com d e f'
+        linker.linkify("a b c jim@example.com d e f") == "a b c jim@example.com d e f"
     )
 
 
 def test_recognized_tags_arg():
     """Verifies that recognized_tags works"""
     # The html parser doesn't recognize "sarcasm" as a tag, so it escapes it
-    linker = Linker(recognized_tags=['p'])
+    linker = Linker(recognized_tags=["p"])
     assert (
-        linker.linkify('<p>http://example.com/</p><sarcasm>') ==
-        '<p><a href="http://example.com/" rel="nofollow">http://example.com/</a></p>&lt;sarcasm&gt;'  # noqa
+        linker.linkify("<p>http://example.com/</p><sarcasm>")
+        == '<p><a href="http://example.com/" rel="nofollow">http://example.com/</a></p>&lt;sarcasm&gt;'  # noqa
     )
 
     # The html parser recognizes "sarcasm" as a tag and fixes it
-    linker = Linker(recognized_tags=['p', 'sarcasm'])
+    linker = Linker(recognized_tags=["p", "sarcasm"])
     assert (
-        linker.linkify('<p>http://example.com/</p><sarcasm>') ==
-        '<p><a href="http://example.com/" rel="nofollow">http://example.com/</a></p><sarcasm></sarcasm>'  # noqa
+        linker.linkify("<p>http://example.com/</p><sarcasm>")
+        == '<p><a href="http://example.com/" rel="nofollow">http://example.com/</a></p><sarcasm></sarcasm>'  # noqa
     )
 
 
 def test_linkify_idempotent():
-    dirty = '<span>invalid & </span> < extra http://link.com<em>'
+    dirty = "<span>invalid & </span> < extra http://link.com<em>"
     assert linkify(linkify(dirty)) == linkify(dirty)
 
 
@@ -656,16 +669,17 @@ class TestLinkify:
 
     def test_rel_already_there(self):
         """Make sure rel attribute is updated not replaced"""
-        linked = ('Click <a href="http://example.com" rel="tooltip">'
-                  'here</a>.')
+        linked = 'Click <a href="http://example.com" rel="tooltip">' "here</a>."
 
-        link_good = 'Click <a href="http://example.com" rel="tooltip nofollow">here</a>.'
+        link_good = (
+            'Click <a href="http://example.com" rel="tooltip nofollow">here</a>.'
+        )
 
         assert linkify(linked) == link_good
         assert linkify(link_good) == link_good
 
     def test_only_text_is_linkified(self):
-        some_text = 'text'
+        some_text = "text"
         some_type = int
         no_type = None
 
@@ -678,22 +692,25 @@ class TestLinkify:
             linkify(no_type)
 
 
-@pytest.mark.parametrize('text, expected', [
-    ('abc', 'abc'),
-    ('example.com', '<a href="http://example.com" rel="nofollow">example.com</a>'),
-    (
-        'http://example.com?b=1&c=2',
-        '<a href="http://example.com?b=1&amp;c=2" rel="nofollow">http://example.com?b=1&amp;c=2</a>'
-    ),
-    (
-        'http://example.com?b=1&amp;c=2',
-        '<a href="http://example.com?b=1&amp;c=2" rel="nofollow">http://example.com?b=1&amp;c=2</a>'
-    ),
-    (
-        'link: https://example.com/watch#anchor',
-        'link: <a href="https://example.com/watch#anchor" rel="nofollow">https://example.com/watch#anchor</a>'
-    )
-])
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("abc", "abc"),
+        ("example.com", '<a href="http://example.com" rel="nofollow">example.com</a>'),
+        (
+            "http://example.com?b=1&c=2",
+            '<a href="http://example.com?b=1&amp;c=2" rel="nofollow">http://example.com?b=1&amp;c=2</a>',
+        ),
+        (
+            "http://example.com?b=1&amp;c=2",
+            '<a href="http://example.com?b=1&amp;c=2" rel="nofollow">http://example.com?b=1&amp;c=2</a>',
+        ),
+        (
+            "link: https://example.com/watch#anchor",
+            'link: <a href="https://example.com/watch#anchor" rel="nofollow">https://example.com/watch#anchor</a>',
+        ),
+    ],
+)
 def test_linkify_filter(text, expected):
     cleaner = Cleaner(filters=[LinkifyFilter])
     assert cleaner.clean(text) == expected

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -7,41 +7,46 @@ from bleach import clean, linkify
 
 
 def test_japanese_safe_simple():
-    assert clean('ヘルプとチュートリアル') == 'ヘルプとチュートリアル'
-    assert linkify('ヘルプとチュートリアル') == 'ヘルプとチュートリアル'
+    assert clean("ヘルプとチュートリアル") == "ヘルプとチュートリアル"
+    assert linkify("ヘルプとチュートリアル") == "ヘルプとチュートリアル"
 
 
 def test_japanese_strip():
-    assert clean('<em>ヘルプとチュートリアル</em>') == '<em>ヘルプとチュートリアル</em>'
-    assert clean('<span>ヘルプとチュートリアル</span>') == '&lt;span&gt;ヘルプとチュートリアル&lt;/span&gt;'
+    assert clean("<em>ヘルプとチュートリアル</em>") == "<em>ヘルプとチュートリアル</em>"
+    assert clean("<span>ヘルプとチュートリアル</span>") == "&lt;span&gt;ヘルプとチュートリアル&lt;/span&gt;"
 
 
 def test_russian_simple():
-    assert clean('Домашняя') == 'Домашняя'
-    assert linkify('Домашняя') == 'Домашняя'
+    assert clean("Домашняя") == "Домашняя"
+    assert linkify("Домашняя") == "Домашняя"
 
 
 def test_mixed():
-    assert clean('Домашняяヘルプとチュートリアル') == 'Домашняяヘルプとチュートリアル'
+    assert clean("Домашняяヘルプとチュートリアル") == "Домашняяヘルプとチュートリアル"
 
 
 def test_mixed_linkify():
     assert (
-        linkify('Домашняя http://example.com ヘルプとチュートリアル') ==
-        'Домашняя <a href="http://example.com" rel="nofollow">http://example.com</a> ヘルプとチュートリアル'
+        linkify("Домашняя http://example.com ヘルプとチュートリアル")
+        == 'Домашняя <a href="http://example.com" rel="nofollow">http://example.com</a> ヘルプとチュートリアル'
     )
 
 
-@pytest.mark.parametrize('test,expected', [
-    ('http://éxámplé.com/', 'http://éxámplé.com/'),
-    ('http://éxámplé.com/íàñá/', 'http://éxámplé.com/íàñá/'),
-    ('http://éxámplé.com/íàñá/?foo=bar', 'http://éxámplé.com/íàñá/?foo=bar'),
-    ('http://éxámplé.com/íàñá/?fóo=bár', 'http://éxámplé.com/íàñá/?fóo=bár'),
-])
+@pytest.mark.parametrize(
+    "test,expected",
+    [
+        ("http://éxámplé.com/", "http://éxámplé.com/"),
+        ("http://éxámplé.com/íàñá/", "http://éxámplé.com/íàñá/"),
+        ("http://éxámplé.com/íàñá/?foo=bar", "http://éxámplé.com/íàñá/?foo=bar"),
+        ("http://éxámplé.com/íàñá/?fóo=bár", "http://éxámplé.com/íàñá/?fóo=bár"),
+    ],
+)
 def test_url_utf8(test, expected):
     """Allow UTF8 characters in URLs themselves."""
-    outs = ('<a href="{0!s}" rel="nofollow">{0!s}</a>',
-            '<a rel="nofollow" href="{0!s}">{0!s}</a>')
+    outs = (
+        '<a href="{0!s}" rel="nofollow">{0!s}</a>',
+        '<a rel="nofollow" href="{0!s}">{0!s}</a>',
+    )
 
     out = lambda url: [x.format(url) for x in outs]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,35 +10,14 @@ class TestAlphabeticalAttributes:
         assert alphabetize_attributes({}) == {}
 
     def test_ordering(self):
-        assert (
-            alphabetize_attributes({
-                (None, 'a'): 1,
-                (None, 'b'): 2
-            }) ==
-            OrderedDict([
-                ((None, 'a'), 1),
-                ((None, 'b'), 2)
-            ])
+        assert alphabetize_attributes({(None, "a"): 1, (None, "b"): 2}) == OrderedDict(
+            [((None, "a"), 1), ((None, "b"), 2)]
         )
-        assert (
-            alphabetize_attributes({
-                (None, 'b'): 1,
-                (None, 'a'): 2}
-            ) ==
-            OrderedDict([
-                ((None, 'a'), 2),
-                ((None, 'b'), 1)
-            ])
+        assert alphabetize_attributes({(None, "b"): 1, (None, "a"): 2}) == OrderedDict(
+            [((None, "a"), 2), ((None, "b"), 1)]
         )
 
     def test_different_namespaces(self):
-        assert (
-            alphabetize_attributes({
-                ('xlink', 'href'): 'abc',
-                (None, 'alt'): '123'
-            }) ==
-            OrderedDict([
-                ((None, 'alt'), '123'),
-                (('xlink', 'href'), 'abc')
-            ])
-        )
+        assert alphabetize_attributes(
+            {("xlink", "href"): "abc", (None, "alt"): "123"}
+        ) == OrderedDict([((None, "alt"), "123"), (("xlink", "href"), "abc")])

--- a/tests_website/data_to_json.py
+++ b/tests_website/data_to_json.py
@@ -22,36 +22,40 @@ import bleach
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        'data_dir',
-        help=(
-            'directory containing test cases with names like <testcase>.test'
-        )
+        "data_dir",
+        help=("directory containing test cases with names like <testcase>.test"),
     )
 
     args = parser.parse_args()
 
     filenames = os.listdir(args.data_dir)
-    ins = [os.path.join(args.data_dir, f) for f in filenames if fnmatch.fnmatch(f, '*.test')]
+    ins = [
+        os.path.join(args.data_dir, f)
+        for f in filenames
+        if fnmatch.fnmatch(f, "*.test")
+    ]
 
     testcases = []
     for infn in ins:
-        case_name = infn.rsplit('.test', 1)[0]
+        case_name = infn.rsplit(".test", 1)[0]
 
-        with open(infn, 'r') as fin:
-            data, expected = fin.read().split('\n--\n')
+        with open(infn, "r") as fin:
+            data, expected = fin.read().split("\n--\n")
             data = data.strip()
             expected = expected.strip()
 
-            testcases.append({
-                'title': case_name,
-                'input_filename': infn,
-                'payload': data,
-                'actual': bleach.clean(data),
-                'expected': expected,
-            })
+            testcases.append(
+                {
+                    "title": case_name,
+                    "input_filename": infn,
+                    "payload": data,
+                    "actual": bleach.clean(data),
+                    "expected": expected,
+                }
+            )
 
     print(json.dumps(testcases, indent=4, sort_keys=True))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests_website/open_test_page.py
+++ b/tests_website/open_test_page.py
@@ -5,7 +5,7 @@ import webbrowser
 
 TEST_BROWSERS = {
     # 'mozilla',
-    'firefox',
+    "firefox",
     # 'netscape',
     # 'galeon',
     # 'epiphany',
@@ -20,17 +20,17 @@ TEST_BROWSERS = {
     # 'elinks',
     # 'lynx',
     # 'w3m',
-    'windows-default',
+    "windows-default",
     # 'macosx',
-    'safari',
+    "safari",
     # 'google-chrome',
-    'chrome',
+    "chrome",
     # 'chromium',
     # 'chromium-browser',
 }
 REGISTERED_BROWSERS = set(webbrowser._browsers.keys())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     for b in TEST_BROWSERS & REGISTERED_BROWSERS:
-        webbrowser.get(b).open_new_tab('http://localhost:8080')
+        webbrowser.get(b).open_new_tab("http://localhost:8080")

--- a/tests_website/server.py
+++ b/tests_website/server.py
@@ -21,32 +21,32 @@ PORT = 8080
 class BleachCleanHandler(six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler):
     def do_POST(self):
         if six.PY2:
-            content_len = int(self.headers.getheader('content-length', 0))
+            content_len = int(self.headers.getheader("content-length", 0))
         else:
-            content_len = int(self.headers.get('content-length', 0))
+            content_len = int(self.headers.get("content-length", 0))
         body = self.rfile.read(content_len)
         print("read %s bytes: %s" % (content_len, body))
 
         if six.PY3:
-            body = body.decode('utf-8')
-        print('input: %r' % body)
+            body = body.decode("utf-8")
+        print("input: %r" % body)
         cleaned = bleach.clean(body)
 
         self.send_response(200)
-        self.send_header('Content-Length', len(cleaned))
-        self.send_header('Content-Type', 'text/plain;charset=UTF-8')
+        self.send_header("Content-Length", len(cleaned))
+        self.send_header("Content-Type", "text/plain;charset=UTF-8")
         self.end_headers()
 
         if six.PY3:
-            cleaned = bytes(cleaned, encoding='utf-8')
+            cleaned = bytes(cleaned, encoding="utf-8")
         print("cleaned: %r" % cleaned)
         self.wfile.write(cleaned)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Prevent 'cannot bind to address' errors on restart
     six.moves.socketserver.TCPServer.allow_reuse_address = True
 
-    httpd = six.moves.socketserver.TCPServer(('127.0.0.1', PORT), BleachCleanHandler)
+    httpd = six.moves.socketserver.TCPServer(("127.0.0.1", PORT), BleachCleanHandler)
     print("listening on localhost port %d" % PORT)
     httpd.serve_forever()

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{27,35,36,37,38,py,py3}
     py{27,35,36,37,38}-build-no-lang
     docs
+    format-check
     lint
     vendorverify
 
@@ -54,6 +55,15 @@ deps =
     -rrequirements-dev.txt
 commands =
     ./run_tests.sh vendorverify
+
+[testenv:format-check]
+basepython = python3.8
+changedir = scripts
+deps =
+    -rrequirements-dev.txt
+    black
+commands =
+    ./run_tests.sh format-check
 
 [testenv:docs]
 basepython = python3.6


### PR DESCRIPTION
* Apply the black formatter to bleach tests and unvendored code
* Add a `format-check` target to `scripts/run-tests.sh`
* Add tox and CI jobs that fail if new code isn't formatting 

Note: that we don't add `black` to `requirements-dev.txt`, because it's Py3 only (refs: #520)