### PR TITLE
Fix 520 drop python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   - "~/.cache/pip"
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -20,9 +19,7 @@ install:
 
 matrix:
   include:
-    - python: "2.7"
-      env: MODE=lint
-    - python: "2.7"
+    - python: "3.8"
       env: MODE=vendorverify
     - python: "3.8"
       env: MODE=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "pypy"
   - "pypy3"
 
 install:

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,21 @@
 Bleach changes
 ==============
 
+Version Next (Unreleased, 2020)
+------------------------------------
+
+**Security fixes**
+
+None
+
+**Features**
+
+* Drop Python 2.7 support #520
+
+**Bug fixes**
+
+None
+
 Version 3.2.1 (September 18th, 2020)
 ------------------------------------
 
@@ -656,7 +671,6 @@ Version 1.2.2 (May 18, 2013)
 ----------------------------
 
 * Pin html5lib to version 0.95 for now due to major API break.
-
 
 Version 1.2.1 (February 19, 2013)
 ---------------------------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.2.x   | :white_check_mark: |
-| < 3.1   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4     | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import packaging.version
 
 from bleach.linkifier import (

--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -18,9 +18,9 @@ from bleach.sanitizer import (
 
 
 # yyyymmdd
-__releasedate__ = "20200918"
+__releasedate__ = ""
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = "3.2.1"
+__version__ = "4.0.0.dev0"
 VERSION = packaging.version.Version(__version__)
 
 

--- a/bleach/callbacks.py
+++ b/bleach/callbacks.py
@@ -1,5 +1,4 @@
 """A set of basic callbacks for bleach.linkify."""
-from __future__ import unicode_literals
 
 
 def nofollow(attrs, new=False):

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -10,8 +10,6 @@ import re
 import string
 import warnings
 
-import six
-
 # ignore html5lib deprecation warnings to use bleach; we are bleach
 # apply before we import submodules that import html5lib
 warnings.filterwarnings(
@@ -244,7 +242,7 @@ class InputStreamWithMemory(object):
         is the "tag" that is being tokenized.
 
         """
-        return six.text_type("").join(self._buffer)
+        return "".join(self._buffer)
 
     def start_tag(self):
         """Resets stream history to just '<'
@@ -458,8 +456,8 @@ def convert_entity(value):
     """
     if value[0] == "#":
         if value[1] in ("x", "X"):
-            return six.unichr(int(value[2:], 16))
-        return six.unichr(int(value[1:], 10))
+            return chr(int(value[2:], 16))
+        return chr(int(value[1:], 10))
 
     return ENTITIES.get(value, None)
 

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -4,8 +4,6 @@ Shim module between Bleach and html5lib. This makes it easier to upgrade the
 html5lib library without having to change a lot of code.
 """
 
-from __future__ import unicode_literals
-
 import re
 import string
 import warnings

--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 import re
-import six
 
 from bleach import callbacks as linkify_callbacks
 from bleach import html5lib_shim
@@ -171,7 +170,7 @@ class Linker(object):
         :raises TypeError: if ``text`` is not a text type
 
         """
-        if not isinstance(text, six.string_types):
+        if not isinstance(text, str):
             raise TypeError("argument must be of text type")
 
         text = force_unicode(text)

--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import re
 
 from bleach import callbacks as linkify_callbacks

--- a/bleach/linkifier.py
+++ b/bleach/linkifier.py
@@ -3,7 +3,7 @@ import re
 
 from bleach import callbacks as linkify_callbacks
 from bleach import html5lib_shim
-from bleach.utils import alphabetize_attributes, force_unicode
+from bleach.utils import alphabetize_attributes
 
 
 #: List of default callbacks
@@ -173,8 +173,6 @@ class Linker(object):
         if not isinstance(text, str):
             raise TypeError("argument must be of text type")
 
-        text = force_unicode(text)
-
         if not text:
             return ""
 
@@ -323,7 +321,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                         new_tokens.extend(
                             [
                                 {"type": "StartTag", "name": "a", "data": attrs},
-                                {"type": "Characters", "data": force_unicode(_text)},
+                                {"type": "Characters", "data": str(_text)},
                                 {"type": "EndTag", "name": "a"},
                             ]
                         )
@@ -447,7 +445,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                         new_tokens.extend(
                             [
                                 {"type": "StartTag", "name": "a", "data": attrs},
-                                {"type": "Characters", "data": force_unicode(_text)},
+                                {"type": "Characters", "data": str(_text)},
                                 {"type": "EndTag", "name": "a"},
                             ]
                         )
@@ -510,7 +508,7 @@ class LinkifyFilter(html5lib_shim.Filter):
                 # all the tokens between the start and end "a" tags and replace
                 # it with the new text
                 yield a_token
-                yield {"type": "Characters", "data": force_unicode(new_text)}
+                yield {"type": "Characters", "data": str(new_text)}
                 yield token_buffer[-1]
 
     def __iter__(self):

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from xml.sax.saxutils import unescape
 
 from bleach import html5lib_shim
-from bleach.utils import alphabetize_attributes, force_unicode
+from bleach.utils import alphabetize_attributes
 
 
 #: List of allowed tags
@@ -169,8 +169,6 @@ class Cleaner(object):
 
         if not text:
             return ""
-
-        text = force_unicode(text)
 
         dom = self.parser.parseFragment(text)
         filtered = BleachSanitizerFilter(

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -4,7 +4,6 @@ from itertools import chain
 import re
 import warnings
 
-import six
 from urllib.parse import urlparse
 from xml.sax.saxutils import unescape
 
@@ -160,7 +159,7 @@ class Cleaner(object):
         :raises TypeError: if ``text`` is not a text type
 
         """
-        if not isinstance(text, six.string_types):
+        if not isinstance(text, str):
             message = (
                 "argument cannot be of '{name}' type, must be of text type".format(
                     name=text.__class__.__name__

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -5,7 +5,7 @@ import re
 import warnings
 
 import six
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from xml.sax.saxutils import unescape
 
 from bleach import html5lib_shim

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from itertools import chain
 import re
 import warnings

--- a/bleach/utils.py
+++ b/bleach/utils.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
 
-import six
-
 
 def _attr_key(attr):
     """Returns appropriate key for sorting attribute names
@@ -21,22 +19,3 @@ def alphabetize_attributes(attrs):
         return attrs
 
     return OrderedDict([(k, v) for k, v in sorted(attrs.items(), key=_attr_key)])
-
-
-def force_unicode(text):
-    """Takes a text (Python 2: str/unicode; Python 3: unicode) and converts to unicode
-
-    :arg str/unicode text: the text in question
-
-    :returns: text as unicode
-
-    :raises UnicodeDecodeError: if the text was a Python 2 str and isn't in
-        utf-8
-
-    """
-    # If it's already unicode, then return it
-    if isinstance(text, six.text_type):
-        return text
-
-    # If not, convert it
-    return six.text_type(text, "utf-8", "strict")

--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -173,7 +173,7 @@ attributes for specified tags:
 
 .. doctest::
 
-   >>> from six.moves.urllib.parse import urlparse
+   >>> from urllib.parse import urlparse
    >>> import bleach
 
    >>> def allow_src(tag, name, value):

--- a/docs/linkify.rst
+++ b/docs/linkify.rst
@@ -109,7 +109,7 @@ an external link:
 
 .. doctest::
 
-   >>> from six.moves.urllib.parse import urlparse
+   >>> from urllib.parse import urlparse
    >>> from bleach.linkifier import Linker
 
    >>> def set_target(attrs, new=False):
@@ -204,7 +204,7 @@ Example of switching all links to go through a bouncer first:
 
 .. doctest::
 
-   >>> from six.moves.urllib.parse import quote, urlparse
+   >>> from urllib.parse import quote, urlparse
    >>> from bleach.linkifier import Linker
 
    >>> def outgoing_bouncer(attrs, new=False):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     include_package_data=True,
     package_data={'': ['README.rst']},
     zip_safe=False,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     install_requires=install_requires,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -54,8 +54,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from bleach.callbacks import nofollow, target_blank
 
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import os
 
 import pytest

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from functools import partial
 from timeit import timeit
 

--- a/tests/test_html5lib_shim.py
+++ b/tests/test_html5lib_shim.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from bleach import html5lib_shim

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import re
 
 import pytest
-from six.moves.urllib_parse import quote_plus
+from urllib.parse import quote_plus
 
 from bleach import linkify, DEFAULT_CALLBACKS as DC
 from bleach.linkifier import Linker, LinkifyFilter

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import re
 
 import pytest

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from bleach import clean, linkify

--- a/tests_website/index.html
+++ b/tests_website/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>Python Bleach 2.0.0</title>
+        <title>Python Bleach 4.0.0</title>
         <style>
          textarea, iframe {
              width: 95%;
@@ -20,7 +20,7 @@
         </style>
     </head>
     <body>
-        <h2>Python Bleach 2.0.0</h2>
+        <h2>Python Bleach 4.0.0</h2>
         <p>
             <a href="http://badge.fury.io/py/bleach"><img style="max-width:100%;" alt="pypi version" src="https://badge.fury.io/py/bleach.svg"></a>
             <a href="https://travis-ci.org/mozilla/bleach"><img style="max-width:100%;" alt="Build Status" src="https://travis-ci.org/mozilla/bleach.svg?branch=master"></a>

--- a/tests_website/open_test_page.py
+++ b/tests_website/open_test_page.py
@@ -28,9 +28,12 @@ TEST_BROWSERS = {
     # 'chromium',
     # 'chromium-browser',
 }
-REGISTERED_BROWSERS = set(webbrowser._browsers.keys())
 
 
 if __name__ == "__main__":
-    for b in TEST_BROWSERS & REGISTERED_BROWSERS:
-        webbrowser.get(b).open_new_tab("http://localhost:8080")
+    for browser_name in TEST_BROWSERS:
+        try:
+            browser = webbrowser.get(browser_name)
+            browser.open_new_tab("http://localhost:8080")
+        except Exception as error:
+            print("error getting test browser %s: %s" % (browser_name, error))

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 envlist =
-    py{35,36,37,38,py,py3}
+    py{35,36,37,38,py3}
     py{35,36,37,38}-build-no-lang
     docs
     format-check

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 
 [tox]
 envlist =
-    py{27,35,36,37,38,py,py3}
-    py{27,35,36,37,38}-build-no-lang
+    py{35,36,37,38,py,py3}
+    py{35,36,37,38}-build-no-lang
     docs
     format-check
     lint
@@ -14,12 +14,6 @@ deps =
     -rrequirements-dev.txt
 commands =
     pytest {posargs:-v}
-    python setup.py build
-
-[testenv:py27-build-no-lang]
-setenv =
-    LANG=
-commands =
     python setup.py build
 
 [testenv:py35-build-no-lang]


### PR DESCRIPTION
Fix #520

Changes:

* update CI and tox configs
* update package `setup.py` metadata and `CHANGES`
* replace `six` in non-vendored code

This doesn't:

*  drop `six` since html5lib needs it
* add type annotations (TODO: later, but we can use the non-comment syntax now)
* change code to take advantage of Python 3 features
* land any other changes planned for the 4.x milestone (thinking add those as time permits and increment the major version number)

I'm planning to squash everything down into 1 to 3 commits if it looks OK.

f? @willkg