### PR TITLE
Allow to preserve order of HTML attributes

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -35,6 +35,7 @@ def clean(
     protocols=ALLOWED_PROTOCOLS,
     strip=False,
     strip_comments=True,
+    alphabetical_attributes=True,
 ):
     """Clean an HTML fragment of malicious content and return it
 
@@ -76,6 +77,8 @@ def clean(
 
     :arg bool strip_comments: whether or not to strip HTML comments
 
+    :arg bool alphabetical_attributes: whether or not to sort HTML attributes
+
     :returns: cleaned text as unicode
 
     """
@@ -86,6 +89,7 @@ def clean(
         protocols=protocols,
         strip=strip,
         strip_comments=strip_comments,
+        alphabetical_attributes=alphabetical_attributes,
     )
     return cleaner.clean(text)
 

--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -93,6 +93,7 @@ class Cleaner(object):
         strip=False,
         strip_comments=True,
         filters=None,
+        alphabetical_attributes=True,
     ):
         """Initializes a Cleaner
 
@@ -129,6 +130,7 @@ class Cleaner(object):
         self.strip = strip
         self.strip_comments = strip_comments
         self.filters = filters or []
+        self.alphabetical_attributes = alphabetical_attributes
 
         self.parser = html5lib_shim.BleachHTMLParser(
             tags=self.tags,
@@ -180,6 +182,7 @@ class Cleaner(object):
             attributes=self.attributes,
             strip_disallowed_elements=self.strip,
             strip_html_comments=self.strip_comments,
+            alphabetical_attributes=self.alphabetical_attributes,
             # html5lib-sanitizer things
             allowed_elements=self.tags,
             allowed_css_properties=self.styles,
@@ -250,6 +253,7 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
         attributes=ALLOWED_ATTRIBUTES,
         strip_disallowed_elements=False,
         strip_html_comments=True,
+        alphabetical_attributes=True,
         **kwargs
     ):
         """Creates a BleachSanitizerFilter instance
@@ -277,6 +281,7 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
         self.attr_filter = attribute_filter_factory(attributes)
         self.strip_disallowed_elements = strip_disallowed_elements
         self.strip_html_comments = strip_html_comments
+        self.alphabetical_attributes = alphabetical_attributes
 
         # filter out html5lib deprecation warnings to use bleach from BleachSanitizerFilter init
         warnings.filterwarnings(
@@ -363,7 +368,7 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
                 return None
 
             else:
-                if "data" in token:
+                if self.alphabetical_attributes and "data" in token:
                     # Alphabetize the attributes before calling .disallowed_token()
                     # so that the resulting string is stable
                     token["data"] = alphabetize_attributes(token["data"])
@@ -553,7 +558,10 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
                 # At this point, we want to keep the attribute, so add it in
                 attrs[namespaced_name] = val
 
-            token["data"] = alphabetize_attributes(attrs)
+            if self.alphabetical_attributes:
+                token["data"] = alphabetize_attributes(attrs)
+            else:
+                token["data"] = attrs
 
         return token
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import os
+import sys
 
 import pytest
 
@@ -780,6 +781,7 @@ def test_regressions(test_case):
     assert clean(test_data) == expected
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_preserve_attributes_order():
     html = """<a target="_blank" href="https://example.com">Link</a>"""
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -780,6 +780,21 @@ def test_regressions(test_case):
     assert clean(test_data) == expected
 
 
+def test_preserve_attributes_order():
+    html = """<a target="_blank" href="https://example.com">Link</a>"""
+
+    cleaned_html = clean(html, tags=["a"], attributes={"a": ["href", "target"]})
+    assert cleaned_html == """<a href="https://example.com" target="_blank">Link</a>"""
+
+    cleaned_preserved_html = clean(
+        html,
+        tags=["a"],
+        attributes={"a": ["href", "target"]},
+        alphabetical_attributes=False,
+    )
+    assert cleaned_preserved_html == html
+
+
 class TestCleaner:
     def test_basics(self):
         TAGS = ["span", "br"]


### PR DESCRIPTION
This would allow to preserve order of HTML attributes. See https://github.com/mozilla/bleach/issues/566 for more details.