### PR TITLE
Remove duplicated h1 in changelog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -223,9 +223,6 @@ None
 
 None
 
-Bleach changes
-==============
-
 Version 3.1.0 (January 9th, 2019)
 ---------------------------------
 


### PR DESCRIPTION
I noticed this while browsing [the docs](https://bleach.readthedocs.io).