### PR TITLE
Fix 598 verify vendor

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -76,7 +76,12 @@ Release process
          $ cd docs/
          $ make doctest
 
-   4. Verify everything works
+   4. Verify the local vendored files (the second invocation should **not** exit with ``/tmp/vendor-test exists. Please remove.`` and the exit code should be zero)::
+
+	$ ./scripts/run_tests.sh vendorverify
+	$ ./scripts/run_tests.sh vendorverify
+
+   5. Run any additional tests to verify everything else works
 
 6. Commit the changes.
 
@@ -92,14 +97,20 @@ Release process
 
      $ python setup.py sdist bdist_wheel
 
-10. Upload them to PyPI::
+10. Sanity check the release contents and sizes:
+
+    $ ls -lh dist/* # file sizes should be similar
+    $ tar tvzf dist/bleach-${VERSION}.tar.gz
+    $ unzip -v dist/bleach-${VERSION}-py2.py3-none-any.whl
+
+11. Upload them to PyPI::
 
       $ twine upload dist/*
 
-11. Push the new tag::
+12. Push the new tag::
 
       $ git push --tags official master
 
     That will push the release to PyPI.
 
-12. Blog posts, twitter, etc.
+13. Blog posts, twitter, etc.

--- a/scripts/vendor_verify.sh
+++ b/scripts/vendor_verify.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Install vendored packages into /tmp and then compare with what's in
 # bleach/_vendor/.
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
     python setup.py build
 
 [testenv:lint]
-basepython = python3.6
+basepython = python3.8
 changedir = scripts
 deps =
     -rrequirements-dev.txt
@@ -49,7 +49,7 @@ commands =
     ./run_tests.sh lint
 
 [testenv:vendorverify]
-basepython = python3.6
+basepython = python3.8
 changedir = scripts
 deps =
     -rrequirements-dev.txt


### PR DESCRIPTION
fix #598 

Changes:
* fix vendor verification script to fail when extra files are included
* update release process docs
* bump python versions in tox for vendorverify and lint tasks

Functional Test:

- [x] ensure vendorverify target fails for additional vendored files
  - [x] add an extra vendored file to `bleach/_vendor`: `touch bleach/_vendor/extra-file`
  - [x] run `./scripts/run_tests.sh vendorverify` and see the following output: 

```
diffing directory trees...
Only in bleach/_vendor/: extra-file
```

  - [x] observe a second run of `./scripts/run_tests.sh vendorverify` failing with (because the first run exited early and didn't clean up after itself):

```
/tmp/vendor-test exists. Please remove.
```