### PR TITLE
Fix semantic whitespace (Issue #369)

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1024,6 +1024,28 @@ def test_html_comments_escaped(namespace_tag, end_tag, eject_tag, data, expected
     )
 
 
+def test_strip_respects_block_level_elements():
+    """
+    Insert a newline between block level elements
+    https://github.com/mozilla/bleach/issues/369
+    """
+    # simple example
+    text = '<p>Te<b>st</b>!</p><p>Hello</p>'
+    assert clean(text, tags=[], strip=True) == 'Test!\nHello'
+
+    # with an internal space and escaped character, just to be sure
+    text = '<p>This is our <b>description!</b> &amp;</p><p>nice!</p>'
+    assert clean(text, tags=[], strip=True) == 'This is our description! &amp;\nnice!'
+
+    # a double-wrap causes an initial newline. this can't really be handled under the current design
+    text = '<div><p>This is our <b>description!</b> &amp;</p></div><p>nice!</p>'
+    assert clean(text, tags=[], strip=True) == '\nThis is our description! &amp;\nnice!'
+
+    # newlines are used to keep lists and other elements readable
+    text = '<div><p>This is our <b>description!</b> &amp;</p><p>1</p><ul><li>a</li><li>b</li><li>c</li></ul></div><p>nice!</p>'
+    assert clean(text, tags=[], strip=True) == '\nThis is our description! &amp;\n1\n\na\nb\nc\nnice!'
+
+
 def get_ids_and_tests():
     """Retrieves regression tests from data/ directory
 


### PR DESCRIPTION
block elements are tracked and a newline is inserted when they are stripped.

new tests are included.

See Issue #369 

This is a simplified rewrite of #461 against the current main