### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 
 [tox]
 envlist =
-    py{36,37,38,39,py3}
-    py{36,37,38,39}-build-no-lang
+    py{36,37,38,39,310,py3}
+    py{36,37,38,39,310}-build-no-lang
     docs
     format-check
     lint
@@ -35,6 +35,12 @@ commands =
     python setup.py build
 
 [testenv:py39-build-no-lang]
+setenv =
+    LANG=
+commands =
+    python setup.py build
+
+[testenv:py310-build-no-lang]
 setenv =
     LANG=
 commands =


### PR DESCRIPTION
Python 3.10.0 RC2 was released [yesterday](https://discuss.python.org/t/python-3-10-0rc2-is-now-available/10496?u=hugovk), 3.10.0 final is due out [2021-10-04](https://www.python.org/dev/peps/pep-0619/).
