### PR TITLE
ci: drop -dev from 3.10 test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
follow up to #614

~~Blocked on support in https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json (latest is 3.10.0-rc.2).~~