### PR TITLE
querystring tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -14,6 +14,18 @@ def test_clean_idempotent():
     assert clean(clean(dirty)) == clean(dirty)
 
 
+def test_clean_idempotent_query():
+    """Make sure that applying the filter twice doesn't change anything."""
+    dirty = '<a href="http://example.com?foo=bar&bar=foo&amp;biz=bash">'
+    assert clean(clean(dirty)) == clean(dirty)
+
+
+def test_clean_idempotent_img():
+    """Make sure that applying the filter twice doesn't change anything."""
+    dirty = '<imr src="http://example.com?foo=bar&bar=foo&amp;biz=bash">'
+    assert clean(clean(dirty, tags=IMG), tags=IMG) == clean(dirty, tags=IMG)
+
+
 def test_only_text_is_cleaned():
     some_text = "text"
     some_type = int

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -667,6 +667,12 @@ def test_linkify_idempotent():
     assert linkify(linkify(dirty)) == linkify(dirty)
 
 
+def test_linkify_idempotent_query():
+    """Make sure that applying the filter twice doesn't change anything."""
+    dirty = '<a href="http://example.com?foo=bar&bar=foo&amp;biz=bash">'
+    assert linkify(linkify(dirty)) == linkify(dirty)
+
+
 class TestLinkify:
     def test_no_href_links(self):
         s = '<a name="anchor">x</a>'


### PR DESCRIPTION
Included are three tests, which I believe should pass in the current version of bleach.  They're from an internal suite that is pinned to an earlier release.

The tests just apply `clean` and `linkify` to urls that have (i) a querystring, with (ii) a normal querystring separator (`&`), and (iii) an html encoded separator (`&amp;`).  The expected output based on historical bleach behavior is that BOTH the raw (`&`) and html encoded (`&amp;`) should be encoded to the html encoding (`&amp;`).

Background:

Our application allows users to edit content.  We ran into a double-encoding issue with query args in some contexts.  These tests helped us rule out the issue coming from bleach, as the bleach test-suite did not cover query args.