### PR TITLE
Remove CODE_OF_CONDUCT.rst (#619)

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,9 +1,0 @@
-Code of conduct
-===============
-
-This project and repository is governed by Mozilla's code of conduct and
-etiquette guidelines. For more details please see the `Mozilla Community
-Participation Guidelines
-<https://www.mozilla.org/about/governance/policies/participation/>`_ and
-`Developer Etiquette Guidelines
-<https://bugzilla.mozilla.org/page.cgi?id=etiquette.html>`_.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -19,10 +19,14 @@ To install Bleach to make changes to it:
        $ pip install -e .
 
 
+Code of conduct
+===============
+
+This project has a `code of conduct
+<https://github.com/mozilla/bleach/blob/main/CODE_OF_CONDUCT.md>`_.
+
+
 .. include:: ../CONTRIBUTING.rst
-
-
-.. include:: ../CODE_OF_CONDUCT.rst
 
 
 Docs


### PR DESCRIPTION
This removes the duplicate reST version of the CODE_OF_CONDUCT.md file.

Fixes #619.