### PR TITLE
Remove packaging dependency (#621)

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -1,5 +1,3 @@
-import packaging.version
-
 from bleach.linkifier import (
     DEFAULT_CALLBACKS,
     Linker,
@@ -17,7 +15,6 @@ from bleach.sanitizer import (
 __releasedate__ = "20210825"
 # x.y.z or x.y.z.dev0 -- semver
 __version__ = "4.1.0"
-VERSION = packaging.version.Version(__version__)
 
 
 __all__ = ["clean", "linkify"]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ def get_version():
 
 
 INSTALL_REQUIRES = [
-    "packaging",
     # html5lib requirements
     "six>=1.9.0",
     "webencodings",


### PR DESCRIPTION
VERSION has been deprecated for ages, so we can remove it and with it,
the only use of the packaging dependency.

Fixes #621