### PR TITLE
Fix character entity handling (#450)

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -512,13 +512,13 @@ def convert_entities(text):
 def match_entity(stream):
     """Returns first entity in stream or None if no entity exists
 
-    Note: For Bleach purposes, entities must start with a "&" and end with
-    a ";". This ignoresambiguous character entities that have no ";" at the
-    end.
+    Note: For Bleach purposes, entities must start with a "&" and end with a
+    ";". This ignores ambiguous character entities that have no ";" at the end.
 
     :arg stream: the character stream
 
-    :returns: ``None`` or the entity string without "&" or ";"
+    :returns: the entity string without "&" or ";" if it's a valid character
+        entity; ``None`` otherwise
 
     """
     # Nix the & at the beginning
@@ -557,13 +557,19 @@ def match_entity(stream):
     # Handle character entities
     while stream and stream[0] not in end_characters:
         c = stream.pop(0)
-        if not ENTITIES_TRIE.has_keys_with_prefix(possible_entity):
-            break
+        print(1, stream, c, possible_entity)
         possible_entity += c
+        if not ENTITIES_TRIE.has_keys_with_prefix(possible_entity):
+            # If it's not a prefix, then it's not an entity and we're
+            # out
+            return None
 
+    print(2, stream, possible_entity)
     if possible_entity and stream and stream[0] == ";":
+        print(3, possible_entity)
         return possible_entity
 
+    print(3, "NONE")
     return None
 
 

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -557,19 +557,15 @@ def match_entity(stream):
     # Handle character entities
     while stream and stream[0] not in end_characters:
         c = stream.pop(0)
-        print(1, stream, c, possible_entity)
         possible_entity += c
         if not ENTITIES_TRIE.has_keys_with_prefix(possible_entity):
             # If it's not a prefix, then it's not an entity and we're
             # out
             return None
 
-    print(2, stream, possible_entity)
     if possible_entity and stream and stream[0] == ";":
-        print(3, possible_entity)
         return possible_entity
 
-    print(3, "NONE")
     return None
 
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -11,11 +11,14 @@ from bleach._vendor.html5lib.constants import rcdataElements
 @pytest.mark.parametrize(
     "data",
     [
-        "<span>text & </span>",
         "a < b",
         "link http://link.com",
         "text<em>",
+        # Verify idempotentcy with character entity handling
+        "<span>text & </span>",
         "jim &current joe",
+        "&&nbsp; &nbsp;&",
+        "jim &xx; joe",
         # Link with querystring items
         '<a href="http://example.com?foo=bar&bar=foo&amp;biz=bash">',
     ],

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -156,41 +156,47 @@ def test_bare_entities_get_escaped_correctly(text, expected):
 @pytest.mark.parametrize(
     "text, expected",
     [
-        # Test character entities
+        # Test character entities in text don't get escaped
         ("&amp;", "&amp;"),
         ("&nbsp;", "&nbsp;"),
         ("&nbsp; test string &nbsp;", "&nbsp; test string &nbsp;"),
         ("&lt;em&gt;strong&lt;/em&gt;", "&lt;em&gt;strong&lt;/em&gt;"),
-        # Test character entity at beginning of string
+        # Test character entity at beginning of string doesn't get escaped
         ("&amp;is cool", "&amp;is cool"),
-        # Test it at the end of the string
+        # Test character entity at end of the string doesn't get escaped
         ("cool &amp;", "cool &amp;"),
-        # Test bare ampersands and entities at beginning
+        # Test bare ampersands before an entity at the beginning of the string
+        # gets escaped
         ("&&amp; is cool", "&amp;&amp; is cool"),
-        # Test entities and bare ampersand at end
+        # Test ampersand after an entity at the end of the string gets escaped
         ("&amp; is cool &amp;&", "&amp; is cool &amp;&amp;"),
-        # Test missing semi-colon means we don't treat it like an entity
+        # Test missing semi-colons mean we don't treat the thing as an entity--Bleach
+        # only recognizes character entities that start with & and end with ;
         ("this &amp that", "this &amp;amp that"),
-        # Test a thing that looks like a character entity, but isn't because it's
-        # missing a ; (&current)
         (
             "http://example.com?active=true&current=true",
             "http://example.com?active=true&amp;current=true",
         ),
-        # Test character entities in attribute values are left alone
+        # Test character entities in attribute values are not escaped
         ('<a href="?art&amp;copy">foo</a>', '<a href="?art&amp;copy">foo</a>'),
         ('<a href="?this=&gt;that">foo</a>', '<a href="?this=&gt;that">foo</a>'),
-        # Ambiguous ampersands get escaped in attributes
+        # Things in attributes that aren't character entities get escaped
         (
             '<a href="http://example.com/&xx;">foo</a>',
             '<a href="http://example.com/&amp;xx;">foo</a>',
         ),
         (
+            '<a href="http://example.com?&adp;">foo</a>',
+            '<a href="http://example.com?&amp;adp;">foo</a>',
+        ),
+        (
             '<a href="http://example.com?active=true&current=true">foo</a>',
             '<a href="http://example.com?active=true&amp;current=true">foo</a>',
         ),
-        # Ambiguous ampersands in text are not escaped
-        ("&xx;", "&xx;"),
+        # Things in text that aren't character entities get escaped
+        ("&xx;", "&amp;xx;"),
+        ("&adp;", "&amp;adp;"),
+        ("&currdupe;", "&amp;currdupe;"),
         # Test numeric entities
         ("&#39;", "&#39;"),
         ("&#34;", "&#34;"),


### PR DESCRIPTION
This fixes a bug where things in the form of a character entity (starts with &, some letters, and ends with ;) that aren't character entities get mangled. Now they are correctly handled.

This also fixes a bug where things in the form of a character entity that aren't character entities should have had the & escaped, but that wasn't happening.

After this, Bleach does the following:

* valid character entities that start with a & and end with a ; are left alone
* things that start with a & and end with a ; and aren't valid character entities are treated as text and the & is escaped
* things that start with a & but don't end with a ; are treated as text and the & is escaped

This is easy to reason about and idempotent and doesn't suffer from ambiguous edge cases where Bleach can't know what the user intended.

I also cleaned up the comments in the tests so it's clearer what we intend Bleach to be doing.

This fixes #450.