### PR TITLE
Support scheme-less urls if "https" is allowed (#662)

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -488,9 +488,9 @@ class BleachSanitizerFilter(html5lib_shim.SanitizerFilter):
             if ":" in new_value and new_value.split(":")[0] in allowed_protocols:
                 return value
 
-            # If there's no protocol/scheme specified, then assume it's "http"
-            # and see if that's allowed
-            if "http" in allowed_protocols:
+            # If there's no protocol/scheme specified, then assume it's "http" or
+            # "https" and see if that's allowed
+            if "http" in allowed_protocols or "https" in allowed_protocols:
                 return value
 
         return None

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -542,10 +542,15 @@ def test_attributes_list():
             {"protocols": []},
             '<a href="#example.com">foo</a>',
         ),
-        # Allow implicit http if allowed
+        # Allow implicit http/https if allowed
         (
             '<a href="/path">valid</a>',
             {"protocols": ["http"]},
+            '<a href="/path">valid</a>',
+        ),
+        (
+            '<a href="/path">valid</a>',
+            {"protocols": ["https"]},
             '<a href="/path">valid</a>',
         ),
         (
@@ -586,7 +591,7 @@ def test_attributes_list():
             ),
             marks=pytest.mark.xfail,
         ),
-        # Disallow implicit http if disallowed
+        # Disallow implicit http/https if disallowed
         ('<a href="example.com">foo</a>', {"protocols": []}, "<a>foo</a>"),
         ('<a href="example.com:8000">foo</a>', {"protocols": []}, "<a>foo</a>"),
         ('<a href="localhost">foo</a>', {"protocols": []}, "<a>foo</a>"),


### PR DESCRIPTION
Previously, we allowed scheme-less urls if "http" was allowed. This
expands that to also support "https".

Fixes #662