### PR TITLE
Update tinycss2 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     "css": [
-        "tinycss2>=1.1.0,<1.2",
+        "tinycss2>=1.2.0,<1.3",
     ],
 }
 


### PR DESCRIPTION
The only breaking change is dropping support of Python 3.6, which bleach already dropped.