### PR TITLE
Add warning when css_sanitizer is not set, but style is allowed (#676)

### DIFF
--- a/bleach/sanitizer.py
+++ b/bleach/sanitizer.py
@@ -48,6 +48,10 @@ INVISIBLE_CHARACTERS_RE = re.compile("[" + INVISIBLE_CHARACTERS + "]", re.UNICOD
 INVISIBLE_REPLACEMENT_CHAR = "?"
 
 
+class NoCssSanitizerWarning(UserWarning):
+    pass
+
+
 class Cleaner:
     """Cleaner for cleaning HTML fragments of malicious content
 
@@ -142,6 +146,25 @@ class Cleaner:
             # clean preserves attr order
             alphabetical_attributes=False,
         )
+
+        if css_sanitizer is None:
+            # FIXME(willkg): this doesn't handle when attributes or an
+            # attributes value is a callable
+            attributes_values = []
+            if isinstance(attributes, list):
+                attributes_values = attributes
+
+            elif isinstance(attributes, dict):
+                attributes_values = []
+                for values in attributes.values():
+                    if isinstance(values, (list, tuple)):
+                        attributes_values.extend(values)
+
+            if "style" in attributes_values:
+                warnings.warn(
+                    "'style' attribute specified, but css_sanitizer not set.",
+                    category=NoCssSanitizerWarning,
+                )
 
     def clean(self, text):
         """Cleans text and returns sanitized result as unicode

--- a/docs/clean.rst
+++ b/docs/clean.rst
@@ -79,6 +79,12 @@ The default value is also a conservative dict found in
 ``bleach.sanitizer.ALLOWED_ATTRIBUTES``.
 
 
+.. Note::
+
+   If you allow ``style``, you need to also sanitize css. See
+   :ref:`clean-chapter-sanitizing-css` for details.
+
+
 .. autodata:: bleach.sanitizer.ALLOWED_ATTRIBUTES
 
 .. versionchanged:: 2.0
@@ -279,6 +285,8 @@ By default, Bleach will strip out HTML comments. To disable this behavior, set
    >>> bleach.clean(html, strip_comments=False)
    'my<!-- commented --> html'
 
+
+.. _clean-chapter-sanitizing-css:
 
 Sanitizing CSS
 ==============

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,6 @@ ignore =
 max-line-length = 88
 
 [tool:pytest]
-addopts = -W error:html5lib:DeprecationWarning
+filterwarnings =
+    error
+    ignore::bleach.sanitizer.NoCssSanitizerWarning

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -4,7 +4,7 @@ import pytest
 
 from bleach import clean
 from bleach.html5lib_shim import Filter
-from bleach.sanitizer import ALLOWED_PROTOCOLS, Cleaner
+from bleach.sanitizer import ALLOWED_PROTOCOLS, Cleaner, NoCssSanitizerWarning
 from bleach._vendor.html5lib.constants import rcdataElements
 
 
@@ -1174,6 +1174,20 @@ def test_preserves_attributes_order():
     cleaned_html = clean(html, tags=["a"], attributes={"a": ["href", "target"]})
 
     assert cleaned_html == html
+
+
+@pytest.mark.parametrize(
+    "attr",
+    (
+        ["style"],
+        {"*": ["style"]},
+    ),
+)
+def test_css_sanitizer_warning(attr):
+    # If you have "style" in attributes, but don't set a css_sanitizer, it
+    # should raise a warning.
+    with pytest.warns(NoCssSanitizerWarning):
+        clean("foo", attributes=attr)
 
 
 class TestCleaner:


### PR DESCRIPTION
This adds a note to the documentation and also adds a warning that gets emitted if css_sanitizer is not set, but "style" is an allowed attribute. This reduces the likelihood of developer error.

Fixes #676.