### PR TITLE
Change elements to tags (#649)

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -52,7 +52,7 @@ def clean(
 
     :arg str text: the text to clean
 
-    :arg list tags: allowed list of tags; defaults to
+    :arg set tags: set of allowed tags; defaults to
         ``bleach.sanitizer.ALLOWED_TAGS``
 
     :arg dict attributes: allowed attributes; can be a callable, list or dict;

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -38,6 +38,9 @@ from bleach._vendor.html5lib.filters.sanitizer import (
     allowed_protocols,
     allowed_css_properties,
     allowed_svg_properties,
+    attr_val_is_uri,
+    svg_attr_val_allows_ref,
+    svg_allow_local_href,
 )  # noqa: E402 module level import not at top of file
 from bleach._vendor.html5lib.filters.sanitizer import (
     Filter as SanitizerFilter,


### PR DESCRIPTION
This cleans up some API weirdness where `BleachSanitizerFilter` subclasses html5lib's sanitizer filter and sets `allowed_elements` to something entirely different than html5lib's sanitizer filter's `allowed_elements` is. The formers is a list of strings. The latter is a frozenset of `(namespace, element)` tuples.

This fixes that by changing the `BleachSanitizerFilter` code to use `allowed_tags` everywhere. This eliminates the API confusion.

While doing this, I changed `ALLOWED_TAGS` to be a frozenset, changed allowed_tags to take a set of strings rather than a list of strings, and renamed `strip_disallowed_elements` to `strip_disallowed_tags` to be consistent with naming. This is a backwards incompatible change we'll need to mention in `CHANGES` and it means a major version change.

I also changed the `__init__` for `BleachSanitizerFilter` so it no longer calls the html5lib sanitizer filter `__init__` which kicks up the deprecation warning.

Fixes #649.