### PR TITLE
Add support for python 3.12 (#710)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,14 @@
 -e .
 
-black==22.12.0; implementation_name == 'cpython'
-build==0.10.0
-mypy==0.991; implementation_name =='cpython'
-pytest==7.2.1
-tox==4.3.5
-tox-gh-actions==3.0.0
+black==23.9.1; implementation_name == 'cpython'
+build==1.0.3
+mypy==1.5.1; implementation_name =='cpython'
+pytest==7.4.2
+setuptools==68.2.2
+tox==4.11.3
+tox-gh-actions==3.1.3
 twine==4.0.2
-wheel==0.38.4
+wheel==0.41.2
 
 # NOTE(willkg): Held back until we drop support for Python 3.7
 Sphinx==5.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 
 [tox]
 envlist =
-    py{38,39,310,311,py3}
-    py{38,39,310,311,py3}-tinycss2
-    py{38,39,310,311}-build-no-lang
+    py{38,39,310,311,312,py3}
+    py{38,39,310,311,312,py3}-tinycss2
+    py{38,39,310,311,312}-build-no-lang
     py39-docs
     py39-format-check
     py39-lint
@@ -16,6 +16,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
     pypy-3.8: pypy3
 
 [testenv]
@@ -48,6 +49,12 @@ extras = css
 commands =
     pytest {posargs:-v}
 
+[testenv:py312-tinycss2]
+deps = -rrequirements-dev.txt
+extras = css
+commands =
+    pytest {posargs:-v}
+
 [testenv:pypy3-tinycss2]
 deps = -rrequirements-dev.txt
 extras = css
@@ -73,6 +80,12 @@ commands =
     python setup.py build
 
 [testenv:py311-build-no-lang]
+setenv =
+    LANG=
+commands =
+    python setup.py build
+
+[testenv:py312-build-no-lang]
 setenv =
     LANG=
 commands =


### PR DESCRIPTION
This adds support for Python 3.12 mostly by adding it to test matrices. This updates dev requirements to pick up versions that fixed Python 3.12 issues.

Fixes #710