### PR TITLE
Handle more cases with < folloed by character data (#705)

### DIFF
--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -395,10 +395,17 @@ class BleachHTMLTokenizer(HTMLTokenizer):
                 # followed by a series of characters. It's treated as a tag
                 # name that abruptly ends, but we should treat that like
                 # character data
-                yield {
-                    "type": TAG_TOKEN_TYPE_CHARACTERS,
-                    "data": "<" + self.currentToken["name"],
-                }
+                yield {"type": TAG_TOKEN_TYPE_CHARACTERS, "data": self.stream.get_tag()}
+            elif last_error_token["data"] in (
+                "eof-in-attribute-name",
+                "eof-in-attribute-value-no-quotes",
+            ):
+                # Handle the case where the text being parsed ends with <
+                # followed by a series of characters and then space and then
+                # more characters. It's treated as a tag name followed by an
+                # attribute that abruptly ends, but we should treat that like
+                # character data.
+                yield {"type": TAG_TOKEN_TYPE_CHARACTERS, "data": self.stream.get_tag()}
             else:
                 yield last_error_token
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -163,6 +163,10 @@ def test_bare_entities_get_escaped_correctly(text, expected):
         ("<y", "&lt;y"),
         ("x < y", "x &lt; y"),
         ("<y>", "&lt;y&gt;"),
+        # this is an eof-in-attribute-name parser error
+        ("<some thing", "&lt;some thing"),
+        # this is an eof-in-attribute-value-no-quotes parser error
+        ("<some thing=foo", "&lt;some thing=foo"),
     ],
 )
 def test_lessthan_escaping(text, expected):


### PR DESCRIPTION
This adds handling for two more cases:

1. something like "<word word". This throws an eof-in-attribute-name parser error.
2. something like "<word word=word". This throws an eof-in-attribute-value-no-quotes error.

Both of these work correctly now.

Fixes #705.