### PR TITLE
really drop python<3.7 support

### DIFF
--- a/bleach/_vendor/html5lib/__init__.py
+++ b/bleach/_vendor/html5lib/__init__.py
@@ -20,7 +20,6 @@ For convenience, this module re-exports the following names:
 * :func:`~.serializer.serialize`
 """
 
-from __future__ import absolute_import, division, unicode_literals
 
 from .html5parser import HTMLParser, parse, parseFragment
 from .treebuilders import getTreeBuilder

--- a/bleach/_vendor/html5lib/_ihatexml.py
+++ b/bleach/_vendor/html5lib/_ihatexml.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 import re
 import warnings
 
@@ -184,7 +182,7 @@ nonXmlNameFirstBMPRegexp = re.compile('[\x00-@\\[-\\^`\\{-\xbf\xd7\xf7\u0132-\u0
 nonPubidCharRegexp = re.compile("[^\x20\x0D\x0Aa-zA-Z0-9\\-'()+,./:=?;!*#@$_%]")
 
 
-class InfosetFilter(object):
+class InfosetFilter:
     replacementRegexp = re.compile(r"U[\dA-F]{5,5}")
 
     def __init__(self,

--- a/bleach/_vendor/html5lib/_inputstream.py
+++ b/bleach/_vendor/html5lib/_inputstream.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from six import text_type
 from six.moves import http_client, urllib
 
@@ -48,7 +46,7 @@ ascii_punctuation_re = re.compile("[\u0009-\u000D\u0020-\u002F\u003A-\u0040\u005
 charsUntilRegEx = {}
 
 
-class BufferedStream(object):
+class BufferedStream:
     """Buffering for streams that do not have buffering of their own
 
     The buffer is implemented as a list of chunks on the assumption that
@@ -131,9 +129,9 @@ def HTMLInputStream(source, **kwargs):
          isinstance(source.fp, http_client.HTTPResponse))):
         isUnicode = False
     elif hasattr(source, "read"):
-        isUnicode = isinstance(source.read(0), text_type)
+        isUnicode = isinstance(source.read(0), str)
     else:
-        isUnicode = isinstance(source, text_type)
+        isUnicode = isinstance(source, str)
 
     if isUnicode:
         encodings = [x for x in kwargs if x.endswith("_encoding")]
@@ -145,7 +143,7 @@ def HTMLInputStream(source, **kwargs):
         return HTMLBinaryInputStream(source, **kwargs)
 
 
-class HTMLUnicodeInputStream(object):
+class HTMLUnicodeInputStream:
     """Provides a unicode stream of characters to the HTMLTokenizer.
 
     This class takes care of character encoding and removing or replacing
@@ -524,7 +522,7 @@ class HTMLBinaryInputStream(HTMLUnicodeInputStream):
             self.rawStream.seek(0)
             self.charEncoding = (newEncoding, "certain")
             self.reset()
-            raise _ReparseException("Encoding changed from %s to %s" % (self.charEncoding[0], newEncoding))
+            raise _ReparseException("Encoding changed from {} to {}".format(self.charEncoding[0], newEncoding))
 
     def detectBOM(self):
         """Attempts to detect at BOM at the start of the stream. If
@@ -673,7 +671,7 @@ class EncodingBytes(bytes):
         return True
 
 
-class EncodingParser(object):
+class EncodingParser:
     """Mini parser for detecting character encoding from meta elements"""
 
     def __init__(self, data):
@@ -861,7 +859,7 @@ class EncodingParser(object):
                 attrValue.append(c)
 
 
-class ContentAttrParser(object):
+class ContentAttrParser:
     def __init__(self, data):
         assert isinstance(data, bytes)
         self.data = data

--- a/bleach/_vendor/html5lib/_tokenizer.py
+++ b/bleach/_vendor/html5lib/_tokenizer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from six import unichr as chr
 
 from collections import deque, OrderedDict
@@ -18,13 +16,10 @@ from ._trie import Trie
 
 entitiesTrie = Trie(entities)
 
-if version_info >= (3, 7):
-    attributeMap = dict
-else:
-    attributeMap = OrderedDict
+attributeMap = dict
 
 
-class HTMLTokenizer(object):
+class HTMLTokenizer:
     """ This class takes care of tokenizing HTML.
 
     * self.currentToken
@@ -50,7 +45,7 @@ class HTMLTokenizer(object):
 
         # The current token being created
         self.currentToken = None
-        super(HTMLTokenizer, self).__init__()
+        super().__init__()
 
     def __iter__(self):
         """ This is where the magic happens.

--- a/bleach/_vendor/html5lib/_trie/__init__.py
+++ b/bleach/_vendor/html5lib/_trie/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from .py import Trie
 
 __all__ = ["Trie"]

--- a/bleach/_vendor/html5lib/_trie/_base.py
+++ b/bleach/_vendor/html5lib/_trie/_base.py
@@ -1,9 +1,7 @@
-from __future__ import absolute_import, division, unicode_literals
-
 try:
     from collections.abc import Mapping
 except ImportError:  # Python 2.7
-    from collections import Mapping
+    from collections.abc import Mapping
 
 
 class Trie(Mapping):
@@ -11,7 +9,7 @@ class Trie(Mapping):
 
     def keys(self, prefix=None):
         # pylint:disable=arguments-differ
-        keys = super(Trie, self).keys()
+        keys = super().keys()
 
         if prefix is None:
             return set(keys)

--- a/bleach/_vendor/html5lib/_trie/py.py
+++ b/bleach/_vendor/html5lib/_trie/py.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
 from six import text_type
 
 from bisect import bisect_left
@@ -8,7 +7,7 @@ from ._base import Trie as ABCTrie
 
 class Trie(ABCTrie):
     def __init__(self, data):
-        if not all(isinstance(x, text_type) for x in data.keys()):
+        if not all(isinstance(x, str) for x in data.keys()):
             raise TypeError("All keys must be strings")
 
         self._data = data

--- a/bleach/_vendor/html5lib/_utils.py
+++ b/bleach/_vendor/html5lib/_utils.py
@@ -1,21 +1,13 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from types import ModuleType
 
 try:
     from collections.abc import Mapping
 except ImportError:
-    from collections import Mapping
+    from collections.abc import Mapping
 
 from six import text_type, PY3
 
-if PY3:
-    import xml.etree.ElementTree as default_etree
-else:
-    try:
-        import xml.etree.cElementTree as default_etree
-    except ImportError:
-        import xml.etree.ElementTree as default_etree
+import xml.etree.ElementTree as default_etree
 
 
 __all__ = ["default_etree", "MethodDispatcher", "isSurrogatePair",
@@ -31,10 +23,10 @@ __all__ = ["default_etree", "MethodDispatcher", "isSurrogatePair",
 # escapes.
 try:
     _x = eval('"\\uD800"')  # pylint:disable=eval-used
-    if not isinstance(_x, text_type):
+    if not isinstance(_x, str):
         # We need this with u"" because of http://bugs.jython.org/issue2039
         _x = eval('u"\\uD800"')  # pylint:disable=eval-used
-        assert isinstance(_x, text_type)
+        assert isinstance(_x, str)
 except Exception:
     supports_lone_surrogates = False
 else:
@@ -122,7 +114,7 @@ def moduleFactoryFactory(factory):
     moduleCache = {}
 
     def moduleFactory(baseModule, *args, **kwargs):
-        if isinstance(ModuleType.__name__, type("")):
+        if isinstance(ModuleType.__name__, str):
             name = "_%s_factory" % baseModule.__name__
         else:
             name = b"_%s_factory" % baseModule.__name__

--- a/bleach/_vendor/html5lib/constants.py
+++ b/bleach/_vendor/html5lib/constants.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 import string
 
 EOF = None

--- a/bleach/_vendor/html5lib/filters/alphabeticalattributes.py
+++ b/bleach/_vendor/html5lib/filters/alphabeticalattributes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from . import base
 
 from collections import OrderedDict

--- a/bleach/_vendor/html5lib/filters/base.py
+++ b/bleach/_vendor/html5lib/filters/base.py
@@ -1,7 +1,4 @@
-from __future__ import absolute_import, division, unicode_literals
-
-
-class Filter(object):
+class Filter:
     def __init__(self, source):
         self.source = source
 

--- a/bleach/_vendor/html5lib/filters/inject_meta_charset.py
+++ b/bleach/_vendor/html5lib/filters/inject_meta_charset.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from . import base
 
 

--- a/bleach/_vendor/html5lib/filters/lint.py
+++ b/bleach/_vendor/html5lib/filters/lint.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from six import text_type
 
 from . import base
@@ -23,7 +21,7 @@ class Filter(base.Filter):
         :arg require_matching_tags: whether or not to require matching tags
 
         """
-        super(Filter, self).__init__(source)
+        super().__init__(source)
         self.require_matching_tags = require_matching_tags
 
     def __iter__(self):
@@ -33,9 +31,9 @@ class Filter(base.Filter):
             if type in ("StartTag", "EmptyTag"):
                 namespace = token["namespace"]
                 name = token["name"]
-                assert namespace is None or isinstance(namespace, text_type)
+                assert namespace is None or isinstance(namespace, str)
                 assert namespace != ""
-                assert isinstance(name, text_type)
+                assert isinstance(name, str)
                 assert name != ""
                 assert isinstance(token["data"], dict)
                 if (not namespace or namespace == namespaces["html"]) and name in voidElements:
@@ -45,49 +43,49 @@ class Filter(base.Filter):
                 if type == "StartTag" and self.require_matching_tags:
                     open_elements.append((namespace, name))
                 for (namespace, name), value in token["data"].items():
-                    assert namespace is None or isinstance(namespace, text_type)
+                    assert namespace is None or isinstance(namespace, str)
                     assert namespace != ""
-                    assert isinstance(name, text_type)
+                    assert isinstance(name, str)
                     assert name != ""
-                    assert isinstance(value, text_type)
+                    assert isinstance(value, str)
 
             elif type == "EndTag":
                 namespace = token["namespace"]
                 name = token["name"]
-                assert namespace is None or isinstance(namespace, text_type)
+                assert namespace is None or isinstance(namespace, str)
                 assert namespace != ""
-                assert isinstance(name, text_type)
+                assert isinstance(name, str)
                 assert name != ""
                 if (not namespace or namespace == namespaces["html"]) and name in voidElements:
-                    assert False, "Void element reported as EndTag token: %(tag)s" % {"tag": name}
+                    assert False, "Void element reported as EndTag token: {tag}".format(tag=name)
                 elif self.require_matching_tags:
                     start = open_elements.pop()
                     assert start == (namespace, name)
 
             elif type == "Comment":
                 data = token["data"]
-                assert isinstance(data, text_type)
+                assert isinstance(data, str)
 
             elif type in ("Characters", "SpaceCharacters"):
                 data = token["data"]
-                assert isinstance(data, text_type)
+                assert isinstance(data, str)
                 assert data != ""
                 if type == "SpaceCharacters":
                     assert data.strip(spaceCharacters) == ""
 
             elif type == "Doctype":
                 name = token["name"]
-                assert name is None or isinstance(name, text_type)
-                assert token["publicId"] is None or isinstance(name, text_type)
-                assert token["systemId"] is None or isinstance(name, text_type)
+                assert name is None or isinstance(name, str)
+                assert token["publicId"] is None or isinstance(name, str)
+                assert token["systemId"] is None or isinstance(name, str)
 
             elif type == "Entity":
-                assert isinstance(token["name"], text_type)
+                assert isinstance(token["name"], str)
 
             elif type == "SerializerError":
-                assert isinstance(token["data"], text_type)
+                assert isinstance(token["data"], str)
 
             else:
-                assert False, "Unknown token type: %(type)s" % {"type": type}
+                assert False, "Unknown token type: {type}".format(type=type)
 
             yield token

--- a/bleach/_vendor/html5lib/filters/optionaltags.py
+++ b/bleach/_vendor/html5lib/filters/optionaltags.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from . import base
 
 

--- a/bleach/_vendor/html5lib/filters/sanitizer.py
+++ b/bleach/_vendor/html5lib/filters/sanitizer.py
@@ -6,13 +6,12 @@ is recommended as a replacement. Please let us know in the aforementioned issue
 if Bleach is unsuitable for your needs.
 
 """
-from __future__ import absolute_import, division, unicode_literals
 
 import re
 import warnings
 from xml.sax.saxutils import escape, unescape
 
-from six.moves import urllib_parse as urlparse
+from urllib import parse as urlparse
 
 from . import base
 from ..constants import namespaces, prefixes
@@ -766,7 +765,7 @@ class Filter(base.Filter):
             hrefs--these are removed
 
         """
-        super(Filter, self).__init__(source)
+        super().__init__(source)
 
         warnings.warn(_deprecation_msg, DeprecationWarning)
 
@@ -874,8 +873,8 @@ class Filter(base.Filter):
             assert token_type in ("StartTag", "EmptyTag")
             attrs = []
             for (ns, name), v in token["data"].items():
-                attrs.append(' %s="%s"' % (name if ns is None else "%s:%s" % (prefixes[ns], name), escape(v)))
-            token["data"] = "<%s%s>" % (token["name"], ''.join(attrs))
+                attrs.append(' {}="{}"'.format(name if ns is None else "{}:{}".format(prefixes[ns], name), escape(v)))
+            token["data"] = "<{}{}>".format(token["name"], ''.join(attrs))
         else:
             token["data"] = "<%s>" % token["name"]
         if token.get("selfClosing"):

--- a/bleach/_vendor/html5lib/filters/whitespace.py
+++ b/bleach/_vendor/html5lib/filters/whitespace.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 import re
 
 from . import base

--- a/bleach/_vendor/html5lib/html5parser.py
+++ b/bleach/_vendor/html5lib/html5parser.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
 from six import with_metaclass, viewkeys
 
 import types
@@ -83,7 +82,7 @@ def method_decorator_metaclass(function):
     return Decorated
 
 
-class HTMLParser(object):
+class HTMLParser:
     """HTML parser
 
     Generates a tree structure from a stream of (possibly malformed) HTML.
@@ -423,7 +422,7 @@ def getPhases(debug):
             return type
 
     # pylint:disable=unused-argument
-    class Phase(with_metaclass(getMetaclass(debug, log))):
+    class Phase(metaclass=getMetaclass(debug, log)):
         """Base class for helper object that implements each phase of processing
         """
         __slots__ = ("parser", "tree", "__startTagCache", "__endTagCache")
@@ -944,7 +943,7 @@ def getPhases(debug):
         __slots__ = ("processSpaceCharacters",)
 
         def __init__(self, *args, **kwargs):
-            super(InBodyPhase, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             # Set this to the default handler
             self.processSpaceCharacters = self.processSpaceCharactersNonPre
 
@@ -1844,7 +1843,7 @@ def getPhases(debug):
         __slots__ = ("originalPhase", "characterTokens")
 
         def __init__(self, *args, **kwargs):
-            super(InTableTextPhase, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             self.originalPhase = None
             self.characterTokens = []
 
@@ -2776,7 +2775,7 @@ def getPhases(debug):
 
 
 def adjust_attributes(token, replacements):
-    needs_adjustment = viewkeys(token['data']) & viewkeys(replacements)
+    needs_adjustment = token['data'].keys() & replacements.keys()
     if needs_adjustment:
         token['data'] = type(token['data'])((replacements.get(k, k), v)
                                             for k, v in token['data'].items())

--- a/bleach/_vendor/html5lib/serializer.py
+++ b/bleach/_vendor/html5lib/serializer.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
 from six import text_type
 
 import re
@@ -101,7 +100,7 @@ def serialize(input, tree="etree", encoding=None, **serializer_opts):
     return s.render(walker(input), encoding)
 
 
-class HTMLSerializer(object):
+class HTMLSerializer:
 
     # attribute quoting options
     quote_attr_values = "legacy"  # be secure by default
@@ -222,14 +221,14 @@ class HTMLSerializer(object):
         self.strict = False
 
     def encode(self, string):
-        assert(isinstance(string, text_type))
+        assert(isinstance(string, str))
         if self.encoding:
             return string.encode(self.encoding, "htmlentityreplace")
         else:
             return string
 
     def encodeStrict(self, string):
-        assert(isinstance(string, text_type))
+        assert(isinstance(string, str))
         if self.encoding:
             return string.encode(self.encoding, "strict")
         else:
@@ -278,7 +277,7 @@ class HTMLSerializer(object):
                         quote_char = "'"
                     else:
                         quote_char = '"'
-                    doctype += " %s%s%s" % (quote_char, token["systemId"], quote_char)
+                    doctype += " {}{}{}".format(quote_char, token["systemId"], quote_char)
 
                 doctype += ">"
                 yield self.encodeStrict(doctype)

--- a/bleach/_vendor/html5lib/treeadapters/__init__.py
+++ b/bleach/_vendor/html5lib/treeadapters/__init__.py
@@ -16,7 +16,6 @@ Example:
    genshi_tree = genshi.to_genshi(TreeWalker(tree))
 
 """
-from __future__ import absolute_import, division, unicode_literals
 
 from . import sax
 

--- a/bleach/_vendor/html5lib/treeadapters/genshi.py
+++ b/bleach/_vendor/html5lib/treeadapters/genshi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from genshi.core import QName, Attrs
 from genshi.core import START, END, TEXT, COMMENT, DOCTYPE
 
@@ -23,7 +21,7 @@ def to_genshi(walker):
 
         if type in ("StartTag", "EmptyTag"):
             if token["namespace"]:
-                name = "{%s}%s" % (token["namespace"], token["name"])
+                name = "{{{}}}{}".format(token["namespace"], token["name"])
             else:
                 name = token["name"]
             attrs = Attrs([(QName("{%s}%s" % attr if attr[0] is not None else attr[1]), value)
@@ -34,7 +32,7 @@ def to_genshi(walker):
 
         if type == "EndTag":
             if token["namespace"]:
-                name = "{%s}%s" % (token["namespace"], token["name"])
+                name = "{{{}}}{}".format(token["namespace"], token["name"])
             else:
                 name = token["name"]
 

--- a/bleach/_vendor/html5lib/treeadapters/sax.py
+++ b/bleach/_vendor/html5lib/treeadapters/sax.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from xml.sax.xmlreader import AttributesNSImpl
 
 from ..constants import adjustForeignAttributes, unadjustForeignAttributes

--- a/bleach/_vendor/html5lib/treebuilders/__init__.py
+++ b/bleach/_vendor/html5lib/treebuilders/__init__.py
@@ -29,7 +29,6 @@ implement several things:
 
 """
 
-from __future__ import absolute_import, division, unicode_literals
 
 from .._utils import default_etree
 

--- a/bleach/_vendor/html5lib/treebuilders/base.py
+++ b/bleach/_vendor/html5lib/treebuilders/base.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
 from six import text_type
 
 from ..constants import scopingElements, tableInsertModeElements, namespaces
@@ -20,7 +19,7 @@ listElementsMap = {
 }
 
 
-class Node(object):
+class Node:
     """Represents an item in the tree"""
     def __init__(self, name):
         """Creates a Node
@@ -43,11 +42,11 @@ class Node(object):
         self._flags = []
 
     def __str__(self):
-        attributesStr = " ".join(["%s=\"%s\"" % (name, value)
+        attributesStr = " ".join(["{}=\"{}\"".format(name, value)
                                   for name, value in
                                   self.attributes.items()])
         if attributesStr:
-            return "<%s %s>" % (self.name, attributesStr)
+            return "<{} {}>".format(self.name, attributesStr)
         else:
             return "<%s>" % (self.name)
 
@@ -143,7 +142,7 @@ class ActiveFormattingElements(list):
         return True
 
 
-class TreeBuilder(object):
+class TreeBuilder:
     """Base treebuilder implementation
 
     * documentClass - the class to use for the bottommost node of a document
@@ -199,7 +198,7 @@ class TreeBuilder(object):
         # match any node with that name
         exactNode = hasattr(target, "nameTuple")
         if not exactNode:
-            if isinstance(target, text_type):
+            if isinstance(target, str):
                 target = (namespaces["html"], target)
             assert isinstance(target, tuple)
 
@@ -322,7 +321,7 @@ class TreeBuilder(object):
 
     def insertElementNormal(self, token):
         name = token["name"]
-        assert isinstance(name, text_type), "Element %s not unicode" % name
+        assert isinstance(name, str), "Element %s not unicode" % name
         namespace = token.get("namespace", self.defaultNamespace)
         element = self.elementClass(name, namespace)
         element.attributes = token["data"]

--- a/bleach/_vendor/html5lib/treebuilders/dom.py
+++ b/bleach/_vendor/html5lib/treebuilders/dom.py
@@ -1,10 +1,7 @@
-from __future__ import absolute_import, division, unicode_literals
-
-
 try:
     from collections.abc import MutableMapping
 except ImportError:  # Python 2.7
-    from collections import MutableMapping
+    from collections.abc import MutableMapping
 from xml.dom import minidom, Node
 import weakref
 
@@ -191,25 +188,25 @@ def getDomBuilder(DomImplementation):
                         rv.append("""|%s<!DOCTYPE %s "%s" "%s">""" %
                                   (' ' * indent, element.name, publicId, systemId))
                     else:
-                        rv.append("|%s<!DOCTYPE %s>" % (' ' * indent, element.name))
+                        rv.append("|{}<!DOCTYPE {}>".format(' ' * indent, element.name))
                 else:
-                    rv.append("|%s<!DOCTYPE >" % (' ' * indent,))
+                    rv.append("|{}<!DOCTYPE >".format(' ' * indent))
             elif element.nodeType == Node.DOCUMENT_NODE:
                 rv.append("#document")
             elif element.nodeType == Node.DOCUMENT_FRAGMENT_NODE:
                 rv.append("#document-fragment")
             elif element.nodeType == Node.COMMENT_NODE:
-                rv.append("|%s<!-- %s -->" % (' ' * indent, element.nodeValue))
+                rv.append("|{}<!-- {} -->".format(' ' * indent, element.nodeValue))
             elif element.nodeType == Node.TEXT_NODE:
-                rv.append("|%s\"%s\"" % (' ' * indent, element.nodeValue))
+                rv.append("|{}\"{}\"".format(' ' * indent, element.nodeValue))
             else:
                 if (hasattr(element, "namespaceURI") and
                         element.namespaceURI is not None):
-                    name = "%s %s" % (constants.prefixes[element.namespaceURI],
+                    name = "{} {}".format(constants.prefixes[element.namespaceURI],
                                       element.nodeName)
                 else:
                     name = element.nodeName
-                rv.append("|%s<%s>" % (' ' * indent, name))
+                rv.append("|{}<{}>".format(' ' * indent, name))
                 if element.hasAttributes():
                     attributes = []
                     for i in range(len(element.attributes)):
@@ -218,13 +215,13 @@ def getDomBuilder(DomImplementation):
                         value = attr.value
                         ns = attr.namespaceURI
                         if ns:
-                            name = "%s %s" % (constants.prefixes[ns], attr.localName)
+                            name = "{} {}".format(constants.prefixes[ns], attr.localName)
                         else:
                             name = attr.nodeName
                         attributes.append((name, value))
 
                     for name, value in sorted(attributes):
-                        rv.append('|%s%s="%s"' % (' ' * (indent + 2), name, value))
+                        rv.append('|{}{}="{}"'.format(' ' * (indent + 2), name, value))
             indent += 2
             for child in element.childNodes:
                 serializeElement(child, indent)

--- a/bleach/_vendor/html5lib/treebuilders/etree.py
+++ b/bleach/_vendor/html5lib/treebuilders/etree.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
 # pylint:disable=protected-access
 
 from six import text_type
@@ -38,7 +37,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
             if namespace is None:
                 etree_tag = name
             else:
-                etree_tag = "{%s}%s" % (namespace, name)
+                etree_tag = "{{{}}}{}".format(namespace, name)
             return etree_tag
 
         def _setName(self, name):
@@ -70,7 +69,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                 # allocation on average
                 for key, value in attributes.items():
                     if isinstance(key, tuple):
-                        name = "{%s}%s" % (key[2], key[1])
+                        name = "{{{}}}{}".format(key[2], key[1])
                     else:
                         name = key
                     el_attrib[name] = value
@@ -210,20 +209,20 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                     rv.append("""<!DOCTYPE %s "%s" "%s">""" %
                               (element.text, publicId, systemId))
                 else:
-                    rv.append("<!DOCTYPE %s>" % (element.text,))
+                    rv.append("<!DOCTYPE {}>".format(element.text))
             elif element.tag == "DOCUMENT_ROOT":
                 rv.append("#document")
                 if element.text is not None:
-                    rv.append("|%s\"%s\"" % (' ' * (indent + 2), element.text))
+                    rv.append("|{}\"{}\"".format(' ' * (indent + 2), element.text))
                 if element.tail is not None:
                     raise TypeError("Document node cannot have tail")
                 if hasattr(element, "attrib") and len(element.attrib):
                     raise TypeError("Document node cannot have attributes")
             elif element.tag == ElementTreeCommentType:
-                rv.append("|%s<!-- %s -->" % (' ' * indent, element.text))
+                rv.append("|{}<!-- {} -->".format(' ' * indent, element.text))
             else:
-                assert isinstance(element.tag, text_type), \
-                    "Expected unicode, got %s, %s" % (type(element.tag), element.tag)
+                assert isinstance(element.tag, str), \
+                    "Expected unicode, got {}, {}".format(type(element.tag), element.tag)
                 nsmatch = tag_regexp.match(element.tag)
 
                 if nsmatch is None:
@@ -231,8 +230,8 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                 else:
                     ns, name = nsmatch.groups()
                     prefix = constants.prefixes[ns]
-                    name = "%s %s" % (prefix, name)
-                rv.append("|%s<%s>" % (' ' * indent, name))
+                    name = "{} {}".format(prefix, name)
+                rv.append("|{}<{}>".format(' ' * indent, name))
 
                 if hasattr(element, "attrib"):
                     attributes = []
@@ -241,20 +240,20 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                         if nsmatch is not None:
                             ns, name = nsmatch.groups()
                             prefix = constants.prefixes[ns]
-                            attr_string = "%s %s" % (prefix, name)
+                            attr_string = "{} {}".format(prefix, name)
                         else:
                             attr_string = name
                         attributes.append((attr_string, value))
 
                     for name, value in sorted(attributes):
-                        rv.append('|%s%s="%s"' % (' ' * (indent + 2), name, value))
+                        rv.append('|{}{}="{}"'.format(' ' * (indent + 2), name, value))
                 if element.text:
-                    rv.append("|%s\"%s\"" % (' ' * (indent + 2), element.text))
+                    rv.append("|{}\"{}\"".format(' ' * (indent + 2), element.text))
             indent += 2
             for child in element:
                 serializeElement(child, indent)
             if element.tail:
-                rv.append("|%s\"%s\"" % (' ' * (indent - 2), element.tail))
+                rv.append("|{}\"{}\"".format(' ' * (indent - 2), element.tail))
         serializeElement(element, 0)
 
         return "\n".join(rv)
@@ -275,7 +274,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                     rv.append("""<!DOCTYPE %s PUBLIC "%s" "%s">""" %
                               (element.text, publicId, systemId))
                 else:
-                    rv.append("<!DOCTYPE %s>" % (element.text,))
+                    rv.append("<!DOCTYPE {}>".format(element.text))
             elif element.tag == "DOCUMENT_ROOT":
                 if element.text is not None:
                     rv.append(element.text)
@@ -288,23 +287,23 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                     serializeElement(child)
 
             elif element.tag == ElementTreeCommentType:
-                rv.append("<!--%s-->" % (element.text,))
+                rv.append("<!--{}-->".format(element.text))
             else:
                 # This is assumed to be an ordinary element
                 if not element.attrib:
-                    rv.append("<%s>" % (filter.fromXmlName(element.tag),))
+                    rv.append("<{}>".format(filter.fromXmlName(element.tag)))
                 else:
-                    attr = " ".join(["%s=\"%s\"" % (
+                    attr = " ".join(["{}=\"{}\"".format(
                         filter.fromXmlName(name), value)
                         for name, value in element.attrib.items()])
-                    rv.append("<%s %s>" % (element.tag, attr))
+                    rv.append("<{} {}>".format(element.tag, attr))
                 if element.text:
                     rv.append(element.text)
 
                 for child in element:
                     serializeElement(child)
 
-                rv.append("</%s>" % (element.tag,))
+                rv.append("</{}>".format(element.tag))
 
             if element.tail:
                 rv.append(element.tail)

--- a/bleach/_vendor/html5lib/treewalkers/__init__.py
+++ b/bleach/_vendor/html5lib/treewalkers/__init__.py
@@ -8,7 +8,6 @@ implements a 'serialize' method which takes a tree as sole argument and
 returns an iterator which generates tokens.
 """
 
-from __future__ import absolute_import, division, unicode_literals
 
 from .. import constants
 from .._utils import default_etree
@@ -96,10 +95,10 @@ def pprint(walker):
                     ns = constants.prefixes[token["namespace"]]
                 else:
                     ns = token["namespace"]
-                name = "%s %s" % (ns, token["name"])
+                name = "{} {}".format(ns, token["name"])
             else:
                 name = token["name"]
-            output.append("%s<%s>" % (" " * indent, name))
+            output.append("{}<{}>".format(" " * indent, name))
             indent += 2
             # attributes (sorted for consistent ordering)
             attrs = token["data"]
@@ -109,10 +108,10 @@ def pprint(walker):
                         ns = constants.prefixes[namespace]
                     else:
                         ns = namespace
-                    name = "%s %s" % (ns, localname)
+                    name = "{} {}".format(ns, localname)
                 else:
                     name = localname
-                output.append("%s%s=\"%s\"" % (" " * indent, name, value))
+                output.append("{}{}=\"{}\"".format(" " * indent, name, value))
             # self-closing
             if type == "EmptyTag":
                 indent -= 2
@@ -121,7 +120,7 @@ def pprint(walker):
             indent -= 2
 
         elif type == "Comment":
-            output.append("%s<!-- %s -->" % (" " * indent, token["data"]))
+            output.append("{}<!-- {} -->".format(" " * indent, token["data"]))
 
         elif type == "Doctype":
             if token["name"]:
@@ -137,13 +136,13 @@ def pprint(walker):
                                    token["name"],
                                    token["systemId"]))
                 else:
-                    output.append("%s<!DOCTYPE %s>" % (" " * indent,
+                    output.append("{}<!DOCTYPE {}>".format(" " * indent,
                                                        token["name"]))
             else:
-                output.append("%s<!DOCTYPE >" % (" " * indent,))
+                output.append("{}<!DOCTYPE >".format(" " * indent))
 
         elif type == "Characters":
-            output.append("%s\"%s\"" % (" " * indent, token["data"]))
+            output.append("{}\"{}\"".format(" " * indent, token["data"]))
 
         elif type == "SpaceCharacters":
             assert False, "concatenateCharacterTokens should have got rid of all Space tokens"

--- a/bleach/_vendor/html5lib/treewalkers/base.py
+++ b/bleach/_vendor/html5lib/treewalkers/base.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from xml.dom import Node
 from ..constants import namespaces, voidElements, spaceCharacters
 
@@ -17,7 +15,7 @@ UNKNOWN = "<#UNKNOWN#>"
 spaceCharacters = "".join(spaceCharacters)
 
 
-class TreeWalker(object):
+class TreeWalker:
     """Walks a tree yielding tokens
 
     Tokens are dicts that all have a ``type`` field specifying the type of the
@@ -201,15 +199,13 @@ class NonRecursiveTreeWalker(TreeWalker):
                 yield self.doctype(*details)
 
             elif type == TEXT:
-                for token in self.text(*details):
-                    yield token
+                yield from self.text(*details)
 
             elif type == ELEMENT:
                 namespace, name, attributes, hasChildren = details
                 if (not namespace or namespace == namespaces["html"]) and name in voidElements:
-                    for token in self.emptyTag(namespace, name, attributes,
-                                               hasChildren):
-                        yield token
+                    yield from self.emptyTag(namespace, name, attributes,
+                                               hasChildren)
                     hasChildren = False
                 else:
                     yield self.startTag(namespace, name, attributes)

--- a/bleach/_vendor/html5lib/treewalkers/dom.py
+++ b/bleach/_vendor/html5lib/treewalkers/dom.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from xml.dom import Node
 
 from . import base

--- a/bleach/_vendor/html5lib/treewalkers/etree.py
+++ b/bleach/_vendor/html5lib/treewalkers/etree.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from collections import OrderedDict
 import re
 
@@ -51,7 +49,7 @@ def getETreeBuilder(ElementTreeImplementation):
                 return base.COMMENT, node.text
 
             else:
-                assert isinstance(node.tag, string_types), type(node.tag)
+                assert isinstance(node.tag, str), type(node.tag)
                 # This is assumed to be an ordinary element
                 match = tag_regexp.match(node.tag)
                 if match:

--- a/bleach/_vendor/html5lib/treewalkers/etree_lxml.py
+++ b/bleach/_vendor/html5lib/treewalkers/etree_lxml.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
 from six import text_type
 
 from collections import OrderedDict
@@ -14,13 +13,13 @@ from .. import _ihatexml
 def ensure_str(s):
     if s is None:
         return None
-    elif isinstance(s, text_type):
+    elif isinstance(s, str):
         return s
     else:
         return s.decode("ascii", "strict")
 
 
-class Root(object):
+class Root:
     def __init__(self, et):
         self.elementtree = et
         self.children = []
@@ -58,7 +57,7 @@ class Root(object):
         return 1
 
 
-class Doctype(object):
+class Doctype:
     def __init__(self, root_node, name, public_id, system_id):
         self.root_node = root_node
         self.name = name
@@ -81,7 +80,7 @@ class FragmentRoot(Root):
         return None
 
 
-class FragmentWrapper(object):
+class FragmentWrapper:
     def __init__(self, fragment_root, obj):
         self.root_node = fragment_root
         self.obj = obj

--- a/bleach/_vendor/html5lib/treewalkers/genshi.py
+++ b/bleach/_vendor/html5lib/treewalkers/genshi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from genshi.core import QName
 from genshi.core import START, END, XML_NAMESPACE, DOCTYPE, TEXT
 from genshi.core import START_NS, END_NS, START_CDATA, END_CDATA, PI, COMMENT
@@ -15,14 +13,12 @@ class TreeWalker(base.TreeWalker):
         previous = None
         for event in self.tree:
             if previous is not None:
-                for token in self.tokens(previous, event):
-                    yield token
+                yield from self.tokens(previous, event)
             previous = event
 
         # Don't forget the final event!
         if previous is not None:
-            for token in self.tokens(previous, None):
-                yield token
+            yield from self.tokens(previous, None)
 
     def tokens(self, event, next):
         kind, data, _ = event
@@ -38,10 +34,9 @@ class TreeWalker(base.TreeWalker):
                     converted_attribs[(None, k)] = v
 
             if namespace == namespaces["html"] and name in voidElements:
-                for token in self.emptyTag(namespace, name, converted_attribs,
+                yield from self.emptyTag(namespace, name, converted_attribs,
                                            not next or next[0] != END or
-                                           next[1] != tag):
-                    yield token
+                                           next[1] != tag)
             else:
                 yield self.startTag(namespace, name, converted_attribs)
 
@@ -55,8 +50,7 @@ class TreeWalker(base.TreeWalker):
             yield self.comment(data)
 
         elif kind == TEXT:
-            for token in self.text(data):
-                yield token
+            yield from self.text(data)
 
         elif kind == DOCTYPE:
             yield self.doctype(*data)

--- a/bleach/_vendor/parse.py
+++ b/bleach/_vendor/parse.py
@@ -126,7 +126,7 @@ def _coerce_args(*args):
     return _decode_args(args) + (_encode_result,)
 
 # Result objects are more helpful than simple tuples
-class _ResultMixinStr(object):
+class _ResultMixinStr:
     """Standard approach to encoding parsed results from str to bytes"""
     __slots__ = ()
 
@@ -134,7 +134,7 @@ class _ResultMixinStr(object):
         return self._encoded_counterpart(*(x.encode(encoding, errors) for x in self))
 
 
-class _ResultMixinBytes(object):
+class _ResultMixinBytes:
     """Standard approach to decoding parsed results from bytes to str"""
     __slots__ = ()
 
@@ -142,7 +142,7 @@ class _ResultMixinBytes(object):
         return self._decoded_counterpart(*(x.decode(encoding, errors) for x in self))
 
 
-class _NetlocResultMixinBase(object):
+class _NetlocResultMixinBase:
     """Shared methods for the parsed result objects containing a netloc element"""
     __slots__ = ()
 
@@ -485,7 +485,7 @@ def urlunparse(components):
     scheme, netloc, url, params, query, fragment, _coerce_result = (
                                                   _coerce_args(*components))
     if params:
-        url = "%s;%s" % (url, params)
+        url = "{};{}".format(url, params)
     return _coerce_result(urlunsplit((scheme, netloc, url, query, fragment)))
 
 def urlunsplit(components):
@@ -745,7 +745,7 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         nv = name_value.split('=', 1)
         if len(nv) != 2:
             if strict_parsing:
-                raise ValueError("bad query field: %r" % (name_value,))
+                raise ValueError("bad query field: {!r}".format(name_value))
             # Handle case of a control-name with no equal sign
             if keep_blank_values:
                 nv.append('')
@@ -791,11 +791,11 @@ class Quoter(collections.defaultdict):
 
     def __repr__(self):
         # Without this, will just display as a defaultdict
-        return "<%s %r>" % (self.__class__.__name__, dict(self))
+        return "<{} {!r}>".format(self.__class__.__name__, dict(self))
 
     def __missing__(self, b):
         # Handle a cache miss. Store quoted string in cache and return.
-        res = chr(b) if b in self.safe else '%{:02X}'.format(b)
+        res = chr(b) if b in self.safe else f'%{b:02X}'
         self[b] = res
         return res
 

--- a/bleach/html5lib_shim.py
+++ b/bleach/html5lib_shim.py
@@ -494,7 +494,7 @@ class BleachHTMLParser(HTMLParser):
 
         """
         self.tags = (
-            frozenset((tag.lower() for tag in tags)) if tags is not None else None
+            frozenset(tag.lower() for tag in tags) if tags is not None else None
         )
         self.strip = strip
         self.consume_entities = consume_entities

--- a/tests_website/open_test_page.py
+++ b/tests_website/open_test_page.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
             browser = webbrowser.get(browser_name)
             browser.open_new_tab("http://localhost:8080")
         except Exception as error:
-            print("error getting test browser {}: {}".format(browser_name, error))
+            print(f"error getting test browser {browser_name}: {error}")

--- a/tests_website/server.py
+++ b/tests_website/server.py
@@ -26,7 +26,7 @@ class BleachCleanHandler(http.server.SimpleHTTPRequestHandler):
     def do_POST(self):
         content_len = int(self.headers.get("content-length", 0))
         body = self.rfile.read(content_len)
-        print("read {} bytes: {}".format(content_len, body))
+        print(f"read {content_len} bytes: {body}")
 
         body = body.decode("utf-8")
         print("input: %r" % body)


### PR DESCRIPTION
Already in pyproject.toml is set support for python>=3.8 however still is used oler syntax.
Filet all python code over `pyupgrade --py3.8-plus`.