### PR TITLE
fix: fix wbr handling (#488)

### DIFF
--- a/bleach/_vendor/02_html5lib_wbr.patch
+++ b/bleach/_vendor/02_html5lib_wbr.patch
@@ -1,0 +1,26 @@
+diff --git bleach/_vendor/html5lib/constants.py b/bleach/_vendor/html5lib/constants.py
+index fe3e237..11184e0 100644
+--- bleach/_vendor/html5lib/constants.py
++++ bleach/_vendor/html5lib/constants.py
+@@ -571,7 +571,8 @@ voidElements = frozenset([
+     "col",
+     "input",
+     "source",
+-    "track"
++    "track",
++    "wbr",
+ ])
+ 
+ cdataElements = frozenset(['title', 'textarea'])
+diff --git bleach/_vendor/html5lib/filters/sanitizer.py b/bleach/_vendor/html5lib/filters/sanitizer.py
+index 5c31e97..74a7c91 100644
+--- bleach/_vendor/html5lib/filters/sanitizer.py
++++ bleach/_vendor/html5lib/filters/sanitizer.py
+@@ -128,6 +128,7 @@ allowed_elements = frozenset((
+     (namespaces['html'], 'ul'),
+     (namespaces['html'], 'var'),
+     (namespaces['html'], 'video'),
++    (namespaces['html'], 'wbr'),
+     (namespaces['mathml'], 'maction'),
+     (namespaces['mathml'], 'math'),
+     (namespaces['mathml'], 'merror'),

--- a/bleach/_vendor/html5lib/constants.py
+++ b/bleach/_vendor/html5lib/constants.py
@@ -571,7 +571,8 @@ voidElements = frozenset([
     "col",
     "input",
     "source",
-    "track"
+    "track",
+    "wbr",
 ])
 
 cdataElements = frozenset(['title', 'textarea'])

--- a/bleach/_vendor/html5lib/filters/sanitizer.py
+++ b/bleach/_vendor/html5lib/filters/sanitizer.py
@@ -128,6 +128,7 @@ allowed_elements = frozenset((
     (namespaces['html'], 'ul'),
     (namespaces['html'], 'var'),
     (namespaces['html'], 'video'),
+    (namespaces['html'], 'wbr'),
     (namespaces['mathml'], 'maction'),
     (namespaces['mathml'], 'math'),
     (namespaces['mathml'], 'merror'),

--- a/bleach/_vendor/vendor_install.sh
+++ b/bleach/_vendor/vendor_install.sh
@@ -12,6 +12,7 @@ pip install --no-binary all --no-compile --no-deps -r "${BLEACH_VENDOR_DIR}/vend
 
 # Apply patches
 (cd "${DEST}" && patch -p2 < 01_html5lib_six.patch)
+(cd "${DEST}" && patch -p2 < 02_html5lib_wbr.patch)
 
 # install Python 3.6.14 urllib.urlparse for #536
 curl --proto '=https' --tlsv1.2 -o "${DEST}/parse.py" https://raw.githubusercontent.com/python/cpython/v3.6.14/Lib/urllib/parse.py

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -736,12 +736,7 @@ def test_nonexistent_namespace():
             ),
         ),
         "track",
-        pytest.param(
-            "wbr",
-            marks=pytest.mark.xfail(
-                reason="https://github.com/mozilla/bleach/issues/488"
-            ),
-        ),
+        "wbr",
     ],
 )
 def test_self_closing_tags_self_close(tag):


### PR DESCRIPTION
html5lib did a 1.1 release in June 2020. Since then, they fixed how wbr is treated--it should be an element that doesn't require a closing tag.

https://github.com/html5lib/html5lib-python/pull/395

However, they haven't done a release since then. This adds another vendor patch to fix wbr handling.