### PR TITLE
Bump upper version limit for tinycss2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     "css": [
-        "tinycss2>=1.1.0,<1.5",
+        "tinycss2>=1.1.0,<2",
     ],
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mozilla/bleach/issues/770

I run `tox -e py314-tinycss2` and it looks all good.