### PR TITLE
fix: fix tox platform restrictions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands =
 
 [testenv:py310-lint]
 changedir = {toxinidir}
-platform = linux
+platform = linux|darwin
 commands =
     ruff format --check --target-version=py310 --exclude=_vendor setup.py bleach/ tests/ tests_website/
     ruff check --target-version=py310 --exclude=_vendor setup.py bleach/ tests/ tests_website/
@@ -101,15 +101,15 @@ commands =
 allowlist_externals = {toxinidir}/scripts/vendor_verify.sh
 changedir = {toxinidir}
 deps = -rrequirements-dev.txt
-platform = linux
+platform = linux|darwin
 commands =
     {toxinidir}/scripts/vendor_verify.sh
 
 [testenv:py310-docs]
 changedir = docs
 deps = -rrequirements-dev.txt
+platform = linux|darwin
 extras = css
-platform = linux
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     sphinx-build -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/doctest


### PR DESCRIPTION
Several environments were restricted to running only on Linux. I'm not really sure why and it prevents me from running tests on macOS. I removed the restriction to see if it passes CI. If it does, we'll keep this fix.